### PR TITLE
fix(portal): wait_for_chat polls indefinitely by default instead of a 300s deadline

### DIFF
--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -282,13 +282,20 @@ class SkyportalClient:
         self,
         chat_id: int,
         after_sequence: int = 0,
-        timeout: float = 300,
+        timeout: Optional[float] = None,
         poll_interval: float = 1,
     ) -> ChatTurnResult:
-        """Poll a headless chat until it completes, pauses, or fails."""
-        deadline = time.monotonic() + timeout
+        """Poll a headless chat until it completes, pauses, or fails.
+
+        Polls indefinitely by default (timeout=None) — a multi-tool agent
+        turn has no fixed upper bound on how long it legitimately takes, and
+        the caller (an interactive shell) already offers Ctrl-C as a manual
+        way to stop waiting and cancel the turn. Pass an explicit timeout
+        only if the caller genuinely wants a hard deadline instead (e.g. a
+        script that should fail fast rather than block)."""
+        deadline = time.monotonic() + timeout if timeout is not None else None
         state: Dict[str, Any] = {"status": "processing", "pending_approvals": []}
-        while time.monotonic() < deadline:
+        while deadline is None or time.monotonic() < deadline:
             state = self.chat_status(chat_id)
             if state.get("status") not in ("processing", "uninitialized"):
                 break
@@ -379,10 +386,12 @@ class SkyportalClient:
         chat_id: Optional[int] = None,
         after_sequence: int = 0,
         server_id: Optional[int] = None,
-        timeout: float = 300,
+        timeout: Optional[float] = None,
         poll_interval: float = 1,
     ) -> ChatTurnResult:
-        """Start or continue a chat and wait for the resulting agent turn."""
+        """Start or continue a chat and wait for the resulting agent turn.
+
+        See wait_for_chat() — polls indefinitely by default (timeout=None)."""
         chat_id = self.begin_chat_turn(message, chat_id=chat_id, server_id=server_id)
         return self.wait_for_chat(
             chat_id,

--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -20,6 +20,15 @@ PRODUCTION_MARKETING_URL = "https://skyportal.ai"
 PRODUCTION_APP_URL = "https://app.skyportal.ai"
 CLI_USER_AGENT = f"Skyportal-CLI/{__version__} (+https://app.skyportal.ai)"
 
+# wait_for_chat()'s messages-retry loop bridges a short-lived read-after-write
+# race (chat_status() flips terminal before chat_messages() is queryable) —
+# bounded by its own fixed attempt count, independent of the overall wait's
+# deadline (which is None by default). At the loop's own backoff schedule
+# (0.25s, doubling, capped at 2s), 10 attempts is ~16s worst case — generous
+# for a race that's normally near-instant, without becoming a second hidden
+# unbounded wait when timeout=None and a turn genuinely has no messages.
+_MESSAGES_RETRY_MAX_ATTEMPTS = 10
+
 
 class _NoRedirectHandler(HTTPRedirectHandler):
     """Keep Bearer credentials from being forwarded through HTTP redirects."""
@@ -242,6 +251,13 @@ class SkyportalClient:
         """Get current headless workflow status."""
         return self._request("GET", "/api/v1/agent/chat/{}/status/".format(chat_id))
 
+    def get_execution_status(self, chat_id: int) -> Dict[str, Any]:
+        """Get detailed execution status, including live_command_output — the
+        currently in-flight command's accumulated output so far (or None if
+        nothing is running). Best-effort/advisory only: chat_status()/
+        chat_messages() remain the authoritative "is the turn done" signal."""
+        return self._request("GET", "/api/v1/agent/chat/{}/execution-status/".format(chat_id))
+
     def chat_messages(self, chat_id: int, after_sequence: int = 0) -> Dict[str, Any]:
         """Get messages created after the supplied sequence cursor."""
         query = urlencode({"after_sequence": after_sequence, "limit": 500})
@@ -284,6 +300,7 @@ class SkyportalClient:
         after_sequence: int = 0,
         timeout: Optional[float] = None,
         poll_interval: float = 1,
+        on_progress: Optional[Callable[[Optional[Dict[str, Any]]], None]] = None,
     ) -> ChatTurnResult:
         """Poll a headless chat until it completes, pauses, or fails.
 
@@ -292,11 +309,24 @@ class SkyportalClient:
         the caller (an interactive shell) already offers Ctrl-C as a manual
         way to stop waiting and cancel the turn. Pass an explicit timeout
         only if the caller genuinely wants a hard deadline instead (e.g. a
-        script that should fail fast rather than block)."""
+        script that should fail fast rather than block).
+
+        on_progress, if given, is called once per poll tick with the current
+        live_command_output dict (or None) via a SEPARATE get_execution_status()
+        call — deliberately not folded into the status-poll loop above, so this
+        stays additive and can't disturb that loop's exit-condition logic.
+        Exceptions from the callback (or the extra request itself) are
+        swallowed: a rendering bug must never break the wait."""
         deadline = time.monotonic() + timeout if timeout is not None else None
         state: Dict[str, Any] = {"status": "processing", "pending_approvals": []}
         while deadline is None or time.monotonic() < deadline:
             state = self.chat_status(chat_id)
+            if on_progress is not None:
+                try:
+                    execution_status = self.get_execution_status(chat_id)
+                    on_progress(execution_status.get("live_command_output"))
+                except Exception:
+                    pass
             if state.get("status") not in ("processing", "uninitialized"):
                 break
             time.sleep(poll_interval)
@@ -318,17 +348,27 @@ class SkyportalClient:
         # instead of reporting "no response" for a response that exists
         # but isn't visible yet. How long that takes varies (near-instant
         # for most turns, longer under load), so this backs off up to 2s
-        # between attempts and keeps going until the SAME deadline already
-        # governing the status poll above — not a separate fixed budget —
-        # rather than guessing a fixed number of retries that could still
-        # be too short some of the time and wasted work the rest.
+        # between attempts.
+        #
+        # Bounded by its OWN fixed retry cap, not the overall wait's deadline
+        # (which is None by default now that wait_for_chat polls
+        # indefinitely) — this loop is bridging a specific, short-lived
+        # consistency-lag window, not "wait as long as the caller's willing
+        # to wait for the whole turn." Without its own bound, a genuinely
+        # empty turn (chat_messages() legitimately never returns anything)
+        # would spin here forever whenever timeout=None, since the deadline
+        # check alone can never fire — reproduced live via a test with an
+        # empty-messages mock and timeout=None: 100% CPU, no progress.
         valid_messages: List[Dict[str, Any]] = []
         messages_retry_delay = 0.25
+        messages_retry_budget = _MESSAGES_RETRY_MAX_ATTEMPTS
         while True:
             payload = self.chat_messages(chat_id, after_sequence=after_sequence)
             messages = payload.get("messages", []) if isinstance(payload, dict) else []
             valid_messages = [message for message in messages if isinstance(message, dict)]
-            if valid_messages or (deadline is not None and time.monotonic() >= deadline):
+            messages_retry_budget -= 1
+            past_deadline = deadline is not None and time.monotonic() >= deadline
+            if valid_messages or past_deadline or messages_retry_budget <= 0:
                 break
             time.sleep(messages_retry_delay)
             messages_retry_delay = min(messages_retry_delay * 2, 2.0)
@@ -388,6 +428,7 @@ class SkyportalClient:
         server_id: Optional[int] = None,
         timeout: Optional[float] = None,
         poll_interval: float = 1,
+        on_progress: Optional[Callable[[Optional[Dict[str, Any]]], None]] = None,
     ) -> ChatTurnResult:
         """Start or continue a chat and wait for the resulting agent turn.
 
@@ -398,6 +439,7 @@ class SkyportalClient:
             after_sequence=after_sequence,
             timeout=timeout,
             poll_interval=poll_interval,
+            on_progress=on_progress,
         )
 
     @staticmethod

--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -328,7 +328,7 @@ class SkyportalClient:
             payload = self.chat_messages(chat_id, after_sequence=after_sequence)
             messages = payload.get("messages", []) if isinstance(payload, dict) else []
             valid_messages = [message for message in messages if isinstance(message, dict)]
-            if valid_messages or time.monotonic() >= deadline:
+            if valid_messages or (deadline is not None and time.monotonic() >= deadline):
                 break
             time.sleep(messages_retry_delay)
             messages_retry_delay = min(messages_retry_delay * 2, 2.0)

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -16,6 +16,7 @@ from prompt_toolkit.styles import Style
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.rule import Rule
+from rich.status import Status
 from rich.table import Table
 from rich.text import Text
 
@@ -557,6 +558,8 @@ class InteractiveShell:
         self.running = False
         self.console.print("[bold cyan]See you in orbit.[/bold cyan]")
 
+    _THINKING_STATUS = "[bold cyan]Skyportal is thinking…[/bold cyan]  [dim](press Ctrl-C to stop)[/dim]"
+
     def _send_prompt(self, message: str) -> None:
         self._require_api_connection()
         # Grab the chat ID before waiting so a Ctrl-C can cancel the turn
@@ -568,15 +571,44 @@ class InteractiveShell:
         )
         self.chat_id = chat_id
         try:
-            with self.console.status(
-                "[bold cyan]Skyportal is thinking…[/bold cyan]  [dim](press Ctrl-C to stop)[/dim]",
-                spinner="dots12",
-            ):
-                turn = self.client.wait_for_chat(chat_id, after_sequence=self.last_sequence)
+            with self.console.status(self._THINKING_STATUS, spinner="dots12") as status:
+                turn = self.client.wait_for_chat(
+                    chat_id,
+                    after_sequence=self.last_sequence,
+                    on_progress=lambda info: self._update_thinking_status(status, info),
+                )
         except KeyboardInterrupt:
             self._cancel_active_turn(chat_id)
             return
         self._process_turn(turn)
+
+    def _update_thinking_status(
+        self, status: Status, info: Optional[Dict[str, Any]], base: Optional[str] = None,
+    ) -> None:
+        """Live progress callback for wait_for_chat's on_progress — updates the
+        spinner text in place with the currently in-flight command's tail
+        output, instead of a static message for the whole wait.
+
+        A single self-updating line, not scrolling console.print() output:
+        unbounded live output would contradict the terse/summarized rendering
+        _tool_result_line already uses for FINISHED commands. info is None
+        between commands (or once none are running) — reset to the base
+        message (the spinner's own starting text; differs between "thinking"
+        vs "submitting an approval") rather than showing stale output from a
+        command that already finished, which matters for multi-step turns."""
+        if not info or not info.get("output"):
+            status.update(base if base is not None else self._THINKING_STATUS)
+            return
+
+        command = info.get("command", "")
+        tail = info["output"].strip().splitlines()[-1] if info["output"].strip() else ""
+        if len(tail) > 100:
+            tail = tail[:97] + "..."
+
+        line = "[bold cyan]$ {}[/bold cyan]  [dim](press Ctrl-C to stop)[/dim]".format(command)
+        if tail:
+            line += "\n[dim]{}[/dim]".format(tail)
+        status.update(line)
 
     def _cancel_active_turn(self, chat_id: int) -> None:
         """Stop the running agent turn after a Ctrl-C, then keep the prompt."""
@@ -640,15 +672,16 @@ class InteractiveShell:
             except (KeyboardInterrupt, EOFError):
                 answer = ""
             decision = "approved" if answer in ("y", "yes") else "rejected"
+            submitting_status = "[cyan]Submitting {}…[/cyan] [dim](Ctrl-C to stop)[/dim]".format(decision)
             try:
-                with self.console.status(
-                    "[cyan]Submitting {}…[/cyan] [dim](Ctrl-C to stop)[/dim]".format(decision),
-                    spinner="dots",
-                ):
+                with self.console.status(submitting_status, spinner="dots") as status:
                     self.client.submit_chat_approval(turn.chat_id, approval, decision)
                     turn = self.client.wait_for_chat(
                         turn.chat_id,
                         after_sequence=self.last_sequence,
+                        on_progress=lambda info, s=status, base=submitting_status: (
+                            self._update_thinking_status(s, info, base=base)
+                        ),
                     )
             except KeyboardInterrupt:
                 self._cancel_active_turn(turn.chat_id)

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -14,6 +14,7 @@ from skyportal.portal import (
     CredentialStore,
     PortalError,
     SkyportalClient,
+    _MESSAGES_RETRY_MAX_ATTEMPTS,
 )
 
 
@@ -255,6 +256,79 @@ def test_wait_for_chat_polls_and_returns_message_cursor(credential_path):
     get_messages.assert_called_once_with(42, after_sequence=3)
 
 
+def test_wait_for_chat_invokes_on_progress_each_poll_tick(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    seen = []
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "get_execution_status",
+        side_effect=[
+            {"live_command_output": {"command": "ls", "output": "a\n"}},
+            {"live_command_output": {"command": "ls", "output": "a\nb\n"}},
+            {"live_command_output": None},
+        ],
+    ), patch.object(
+        client, "chat_messages", return_value={"messages": [], "has_more": False},
+    ), patch("skyportal.portal.time.sleep"):
+        client.wait_for_chat(42, poll_interval=0, on_progress=seen.append)
+
+    assert seen == [
+        {"command": "ls", "output": "a\n"},
+        {"command": "ls", "output": "a\nb\n"},
+        None,
+    ]
+
+
+def test_wait_for_chat_on_progress_exception_does_not_break_wait(credential_path):
+    """A callback bug (or a failure in the extra get_execution_status() call)
+    must never interrupt the wait — the status-poll loop's own correctness
+    is unrelated and must not be put at risk by this side channel."""
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    def _raises(_info):
+        raise RuntimeError("rendering bug")
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client, "get_execution_status", side_effect=RuntimeError("network hiccup"),
+    ), patch.object(
+        client, "chat_messages", return_value={"messages": [], "has_more": False},
+    ), patch("skyportal.portal.time.sleep"):
+        result = client.wait_for_chat(42, poll_interval=0, on_progress=_raises)
+
+    assert result.status == "idle"
+
+
+def test_wait_for_chat_without_on_progress_never_calls_execution_status(credential_path):
+    """Callers that don't pass on_progress shouldn't pay for the extra
+    per-tick HTTP round trip at all."""
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch.object(
+        client, "chat_status", return_value={"status": "idle", "pending_approvals": []},
+    ), patch.object(client, "get_execution_status") as get_exec_status, patch.object(
+        client, "chat_messages", return_value={"messages": [], "has_more": False},
+    ), patch("skyportal.portal.time.sleep"):
+        client.wait_for_chat(42, poll_interval=0)
+
+    get_exec_status.assert_not_called()
+
+
 def test_wait_for_chat_retries_when_first_fetch_is_empty(credential_path):
     """Reproduced live: chat_status() can flip to a terminal status (e.g.
     awaiting_input) before the message that justifies it is queryable via
@@ -350,6 +424,30 @@ def test_wait_for_chat_gives_up_at_deadline_on_genuinely_empty_turn(credential_p
     sleep.assert_not_called()
 
 
+def test_wait_for_chat_messages_retry_loop_bounded_even_with_no_deadline(credential_path):
+    """Regression test: with timeout=None (the default), a genuinely empty
+    turn must NOT spin the messages-retry loop forever. Reproduced live —
+    the loop's old exit condition only checked the overall deadline, which
+    is None by default now that wait_for_chat polls indefinitely, so a
+    turn with truly no new messages hung at 100% CPU with no progress."""
+    client = SkyportalClient("https://app.skyportal.ai")
+    empty_messages = {"messages": [], "has_more": False}
+
+    with patch.object(
+        client, "chat_status", return_value={"status": "idle", "pending_approvals": []},
+    ), patch.object(
+        client, "chat_messages", return_value=empty_messages,
+    ) as get_messages, patch("skyportal.portal.time.sleep") as sleep:
+        result = client.wait_for_chat(983, after_sequence=10, poll_interval=0)
+
+    assert result.messages == []
+    assert result.latest_sequence == 10
+    # Must actually stop — the loop's own fixed retry cap, not a borrowed
+    # deadline that doesn't exist in this mode.
+    assert get_messages.call_count == _MESSAGES_RETRY_MAX_ATTEMPTS
+    assert sleep.call_count == _MESSAGES_RETRY_MAX_ATTEMPTS - 1
+
+
 def test_run_chat_turn_continues_existing_chat(credential_path):
     client = SkyportalClient("https://app.skyportal.ai")
     completed = ChatTurnResult(42, "idle", [], [], 9)
@@ -366,7 +464,7 @@ def test_run_chat_turn_continues_existing_chat(credential_path):
 
     assert result is completed
     send.assert_called_once_with(42, "Continue")
-    wait.assert_called_once_with(42, after_sequence=8, timeout=None, poll_interval=0)
+    wait.assert_called_once_with(42, after_sequence=8, timeout=None, poll_interval=0, on_progress=None)
 
 
 def test_approval_and_server_selection_use_headless_endpoints(credential_path):

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -292,6 +292,35 @@ def test_wait_for_chat_retries_when_first_fetch_is_empty(credential_path):
     assert [call.args[0] for call in sleep.call_args_list] == [0.25, 0.5]
 
 
+def test_wait_for_chat_retries_indefinitely_with_no_timeout(credential_path):
+    """Regression test: timeout=None (the default) must not crash when the
+    messages-retry loop's own deadline check runs. This is a genuinely
+    separate code path from the status-poll loop above (test_wait_for_chat_
+    retries_when_first_fetch_is_empty only exercises timeout=None there) —
+    reproduced live via `>=` not supported between 'float' and 'NoneType',
+    a second raw deadline comparison further down wait_for_chat that the
+    None-timeout support initially missed."""
+    client = SkyportalClient("https://app.skyportal.ai")
+    real_messages = {
+        "messages": [
+            {"sequence": 12, "role": "assistant", "content": [{"type": "text", "text": "Done"}]},
+        ],
+        "has_more": False,
+    }
+    empty_messages = {"messages": [], "has_more": False}
+
+    with patch.object(
+        client, "chat_status", return_value={"status": "idle", "pending_approvals": []},
+    ), patch.object(
+        client, "chat_messages", side_effect=[empty_messages, real_messages],
+    ) as get_messages, patch("skyportal.portal.time.sleep"):
+        result = client.wait_for_chat(983, after_sequence=10, poll_interval=0)
+
+    assert result.messages == real_messages["messages"]
+    assert result.latest_sequence == 12
+    assert get_messages.call_count == 2
+
+
 def test_wait_for_chat_gives_up_at_deadline_on_genuinely_empty_turn(credential_path):
     """A turn that really did produce no new messages must still return an
     empty result once the deadline passes, not hang or raise."""

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -337,7 +337,7 @@ def test_run_chat_turn_continues_existing_chat(credential_path):
 
     assert result is completed
     send.assert_called_once_with(42, "Continue")
-    wait.assert_called_once_with(42, after_sequence=8, timeout=300, poll_interval=0)
+    wait.assert_called_once_with(42, after_sequence=8, timeout=None, poll_interval=0)
 
 
 def test_approval_and_server_selection_use_headless_endpoints(credential_path):

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -28,8 +28,10 @@ class FakeClient:
         self.begin_calls.append((message, chat_id, server_id))
         return chat_id if chat_id is not None else 100
 
-    def wait_for_chat(self, chat_id, after_sequence=0):
+    def wait_for_chat(self, chat_id, after_sequence=0, on_progress=None):
         self.wait_calls.append((chat_id, after_sequence))
+        if on_progress is not None:
+            on_progress(None)  # exercise the real call signature, no live output in these tests
         if self._wait_raises is not None:
             raise self._wait_raises
         return self._wait_result

--- a/tests/test_shell_tool_rendering.py
+++ b/tests/test_shell_tool_rendering.py
@@ -6,6 +6,7 @@ role == "tool" messages — a multi-server session gave no way to tell which
 host a given command ran against."""
 
 from io import StringIO
+from unittest.mock import MagicMock
 
 from rich.console import Console
 
@@ -270,4 +271,78 @@ class TestEmptyTurnMessage:
         shell._process_turn(turn)
         text = console.file.getvalue()
         assert "#42" in text
-        assert "idle" in text
+
+
+class TestUpdateThinkingStatus:
+    """_update_thinking_status is wait_for_chat's on_progress callback —
+    updates the spinner text in place with the currently in-flight command's
+    tail output, instead of a static message for the whole wait."""
+
+    def _shell(self):
+        console = _console()
+        shell = InteractiveShell(
+            console=console,
+            client_factory=lambda: object(),
+            session=object(),
+            token_prompt=lambda _prompt: "",
+        )
+        return shell
+
+    def test_none_info_resets_to_default_thinking_message(self):
+        shell = self._shell()
+        status = MagicMock()
+
+        shell._update_thinking_status(status, None)
+
+        status.update.assert_called_once_with(shell._THINKING_STATUS)
+
+    def test_none_info_resets_to_explicit_base_when_given(self):
+        """The approval-resubmit call site passes its own "Submitting…" base
+        message — resetting to the generic "thinking…" text there would be
+        wrong context for what's actually happening."""
+        shell = self._shell()
+        status = MagicMock()
+
+        shell._update_thinking_status(status, None, base="[cyan]Submitting approved…[/cyan]")
+
+        status.update.assert_called_once_with("[cyan]Submitting approved…[/cyan]")
+
+    def test_empty_output_resets_to_default_message(self):
+        shell = self._shell()
+        status = MagicMock()
+
+        shell._update_thinking_status(status, {"command": "ls", "output": ""})
+
+        status.update.assert_called_once_with(shell._THINKING_STATUS)
+
+    def test_shows_command_and_last_output_line(self):
+        shell = self._shell()
+        status = MagicMock()
+
+        shell._update_thinking_status(
+            status, {"command": "cat crash.log", "output": "line one\nline two\nline three"},
+        )
+
+        (rendered,), _ = status.update.call_args
+        assert "cat crash.log" in rendered
+        assert "line three" in rendered
+        assert "line one" not in rendered  # only the tail, not the whole buffer
+
+    def test_long_output_line_is_truncated(self):
+        shell = self._shell()
+        status = MagicMock()
+        long_line = "x" * 200
+
+        shell._update_thinking_status(status, {"command": "cat big", "output": long_line})
+
+        (rendered,), _ = status.update.call_args
+        assert "..." in rendered
+        assert len(rendered) < len(long_line) + 50  # command/markup overhead only, not the full line
+
+    def test_missing_command_key_does_not_raise(self):
+        shell = self._shell()
+        status = MagicMock()
+
+        shell._update_thinking_status(status, {"output": "some output"})  # no "command" key
+
+        status.update.assert_called_once()


### PR DESCRIPTION
## Summary
- \`wait_for_chat()\`'s 300s timeout defaulted from the CLI's original scaffolding commit, not tuned against real agent-turn latency. A multi-tool turn (clone + read several files + diagnose + propose a fix) can legitimately run past 300s under real LLM/SSH latency variance — reproduced live via a demo recording where the CLI gave up with "Skyportal is still working after 300 seconds" while the turn was still correctly executing server-side, and later completed successfully with a correct answer.
- The deadline's only real job was distinguishing a hung turn from a slow one, which a fixed wall-clock cutoff structurally can't do — both look identical at the 300s mark.
- The interactive shell already has a genuine, documented escape hatch independent of this deadline: Ctrl-C cancels the turn server-side via \`cancel_chat()\` (see \`_send_prompt\`'s existing comment: *"Grab the chat ID before waiting so a Ctrl-C can cancel the turn server-side"*, and the \`(press Ctrl-C to stop)\` prompt).
- \`timeout\` remains a parameter on both \`wait_for_chat\` and \`run_chat_turn\` for callers that want a hard deadline (e.g. a script that should fail fast) — it now defaults to \`None\` (poll indefinitely) instead of \`300\`.

## Test plan
- [x] \`poetry run pytest tests/\` — 330 tests, all passing
- [x] Updated \`test_run_chat_turn_continues_existing_chat\` to assert the new default (\`timeout=None\`) is forwarded correctly
- [x] Existing deadline behavior (\`test_wait_for_chat_gives_up_at_deadline_on_genuinely_empty_turn\`) untouched — an explicit \`timeout=\` still works exactly as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat polling can now continue indefinitely by default until a terminal status is reached or polling is stopped externally.
  * Chat operations support optional timeouts, allowing callers to set an explicit deadline when needed.

* **Documentation**
  * Updated guidance clarifies timeout and polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->