### PR TITLE
update for multi host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ cd skyportalai
 ./run.sh
 ```
 
-Inside the terminal, run `/login` once, select a server with `/servers`, and ask
-what changed:
+Inside the terminal, run `/login` once, list infrastructure with `/servers`,
+select one or more hosts with `/server`, and ask what changed:
 
 ```text
 skyportal [connected] > diagnose the latest deployment
@@ -63,7 +63,7 @@ Useful commands:
 ```text
 /login          Connect your Skyportal account
 /servers        List available infrastructure
-/server <id>    Select a server
+/server <id> [id ...]  Select one or more servers; the first is the default
 /status         Show the active context
 /new            Start a new investigation
 /resume         Continue the previous investigation
@@ -86,6 +86,29 @@ with Skyportal(api_key="sk-...") as client:
     print(result.status)
 ```
 
+To make the full multi-host scope available to the first turn, create the chat
+with repeatable server scope and an active default:
+
+```python
+with Skyportal(api_key="sk-...") as client:
+    chat = client.chat.create_chat(
+        "Compare GPU health on all selected hosts",
+        server_ids=[12, 18],
+        active_server_id=12,
+        selected_namespaces={18: ["default", "vllm"]},
+    )
+    result = chat.wait(on_approval=lambda approval: True)
+```
+
+The scope is an allowlist: the active server handles an ambiguous command, and
+the agent broadcasts only when the prompt explicitly targets all selected
+hosts. Use `{"18": ["__all__"]}` for every Kubernetes namespace, omit
+`selected_namespaces` when no Kubernetes scope is needed, and use
+`chat.select_servers(...)` between turns to replace an existing chat's scope.
+When replacing scope, omitting namespace data preserves retained selections
+while `{}` clears them. The singular `server_id=12` creation form remains
+supported.
+
 Set `SKYPORTAL_API_KEY` instead of passing a key directly. The client also
 supports `SKYPORTAL_BASE_URL` for self-hosted deployments.
 
@@ -95,8 +118,23 @@ The `skyportalai` command provides stable JSON output for scripts and CI:
 
 ```bash
 skyportalai chat send --server 12 --wait "Diagnose the latest regression"
+skyportalai chat send --server 12 --server 18 \
+  --namespace 18=default --namespace 18=vllm --wait \
+  "Compare GPU health on all selected hosts"
 skyportalai --json chat messages 123
 ```
+
+Set the full scope of an existing chat between turns with repeatable `--server`
+options:
+
+```bash
+skyportalai chat select-servers 123 \
+  --server 12 --server 18 --active-server 12 \
+  --namespace 18=default --namespace 18=vllm
+skyportalai chat send --chat-id 123 --wait "Compare all selected hosts"
+```
+
+Use `--clear-scope` to remove every selected server explicitly.
 
 Run `skyportalai --help` for the complete command reference.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,31 @@ an unexpected origin or sent in cleartext.
 
 ## Server context
 
-`GET /api/v1/experiments/my-servers/` provides the authenticated account's owned servers. A selected server is included when creating a chat or sent to `/select-server/` for an existing chat.
+`GET /api/v1/experiments/my-servers/` provides the authenticated account's
+owned servers. Chat creation accepts either the backward-compatible
+`server_id` field or an atomic first-turn scope with `selected_server_ids`,
+`active_server_id`, `active_host_id`, and `selected_namespaces`. The singular
+and plural forms are mutually exclusive. A single selection can also be sent
+to `/select-server/` for an existing chat.
+
+For an existing chat that is not actively processing, `POST
+/api/v1/agent/chat/{id}/select-servers/` replaces the complete execution
+allowlist. It can also choose the default execution server, preserve or update
+the terminal/Jupyter binding, and set per-server Kubernetes namespace scope.
+Omitted namespace data preserves choices for retained servers, `{}` clears all
+namespace choices, and `__all__` represents cluster-wide namespace access.
+Multi-server scope does not make every command a broadcast: the prompt must
+explicitly target all selected hosts.
+
+The plural creation fields are persisted before first-turn processing starts,
+so every tool sees the complete allowlist from the beginning. Scope changes on
+an existing chat still happen only while it is not actively processing. The
+website serializes REST and browser turns and scope mutations with the same
+token-owned Redis lease, rejects changes while approvals are pending, and
+renews the lease during long turns; losing ownership cancels the local worker
+instead of allowing two clients to execute against different scopes.
+The interactive `skyportal` shell accepts multiple IDs with `/server 12 18`,
+and the one-shot `skyportal ask` command accepts repeated `--server` options.
 
 ## Local state
 

--- a/skyportal/cli.py
+++ b/skyportal/cli.py
@@ -158,14 +158,32 @@ def github_token_remove() -> None:
 
 @main.command()
 @click.argument("message", required=False)
-@click.option("--server", "server_id", type=int, help="Target one owned server ID")
-def ask(message: Optional[str], server_id: Optional[int]) -> None:
+@click.option(
+    "--server",
+    "server_ids",
+    type=int,
+    multiple=True,
+    help="Target a server ID; repeat to scope the first turn to multiple hosts",
+)
+def ask(message: Optional[str], server_ids: tuple[int, ...]) -> None:
     """Send one message to the Skyportal Agent."""
     prompt = message or click.prompt("Message")
     client = _portal_client()
     try:
         with console.status("[cyan]Skyportal is thinking…[/cyan]", spinner="dots12"):
-            turn = client.run_chat_turn(prompt, server_id=server_id)
+            selected = list(dict.fromkeys(server_ids))
+            if len(selected) == 1:
+                # Preserve the established singular request for deployments
+                # that predate the plural first-turn scope contract.
+                turn = client.run_chat_turn(prompt, server_id=selected[0])
+            elif selected:
+                turn = client.run_chat_turn(
+                    prompt,
+                    server_ids=selected,
+                    active_server_id=selected[0],
+                )
+            else:
+                turn = client.run_chat_turn(prompt)
     except PortalError as error:
         raise click.ClickException(str(error)) from error
     response = client.assistant_text(turn.messages)

--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -224,11 +224,42 @@ class SkyportalClient:
         """List servers owned by the authenticated user."""
         return self._request("GET", "/api/v1/experiments/my-servers/")
 
-    def create_chat(self, message: str, server_id: Optional[int] = None) -> Dict[str, Any]:
-        """Create a headless chat and start its first turn."""
+    def create_chat(
+        self,
+        message: str,
+        server_id: Optional[int] = None,
+        *,
+        server_ids: Optional[List[int]] = None,
+        active_server_id: Optional[int] = None,
+        active_host_id: Optional[int] = None,
+        selected_namespaces: Optional[Dict[Any, List[str]]] = None,
+    ) -> Dict[str, Any]:
+        """Create a headless chat and atomically scope its first turn."""
+        if server_id is not None and server_ids is not None:
+            raise PortalError("Use server_id or server_ids, not both")
+        if server_ids is None and (
+            active_server_id is not None
+            or active_host_id is not None
+            or selected_namespaces is not None
+        ):
+            raise PortalError(
+                "server_ids is required with active_server_id, active_host_id, "
+                "or selected_namespaces"
+            )
         body: Dict[str, Any] = {"message": message}
         if server_id is not None:
             body["server_id"] = server_id
+        if server_ids is not None:
+            deduped = list(dict.fromkeys(int(value) for value in server_ids))
+            body["selected_server_ids"] = deduped
+            if active_server_id is None and deduped:
+                active_server_id = deduped[0]
+        if active_server_id is not None:
+            body["active_server_id"] = active_server_id
+        if active_host_id is not None:
+            body["active_host_id"] = active_host_id
+        if selected_namespaces is not None:
+            body["selected_namespaces"] = selected_namespaces
         return self._request("POST", "/api/v1/agent/chat/", json_body=body)
 
     def send_chat_message(self, chat_id: int, message: str) -> Dict[str, Any]:
@@ -277,6 +308,32 @@ class SkyportalClient:
             "POST",
             "/api/v1/agent/chat/{}/select-server/".format(chat_id),
             json_body={"server_id": server_id},
+        )
+
+    def select_chat_servers(
+        self,
+        chat_id: int,
+        server_ids: List[int],
+        *,
+        active_server_id: Optional[int] = None,
+        active_host_id: Optional[int] = None,
+        selected_namespaces: Optional[Dict[Any, List[str]]] = None,
+    ) -> Dict[str, Any]:
+        """Replace an existing chat's complete multi-server scope."""
+        deduped = list(dict.fromkeys(int(value) for value in server_ids))
+        body: Dict[str, Any] = {"selected_server_ids": deduped}
+        if active_server_id is None and deduped:
+            active_server_id = deduped[0]
+        if active_server_id is not None:
+            body["active_server_id"] = active_server_id
+        if active_host_id is not None:
+            body["active_host_id"] = active_host_id
+        if selected_namespaces is not None:
+            body["selected_namespaces"] = selected_namespaces
+        return self._request(
+            "POST",
+            "/api/v1/agent/chat/{}/select-servers/".format(chat_id),
+            json_body=body,
         )
 
     def wait_for_chat(
@@ -348,6 +405,11 @@ class SkyportalClient:
         message: str,
         chat_id: Optional[int] = None,
         server_id: Optional[int] = None,
+        *,
+        server_ids: Optional[List[int]] = None,
+        active_server_id: Optional[int] = None,
+        active_host_id: Optional[int] = None,
+        selected_namespaces: Optional[Dict[Any, List[str]]] = None,
     ) -> int:
         """Start or continue a chat and return its ID without waiting.
 
@@ -355,7 +417,22 @@ class SkyportalClient:
         ID up front, so it can cancel the turn while the agent is still working.
         """
         if chat_id is None:
-            started = self.create_chat(message, server_id=server_id)
+            if (
+                server_ids is None
+                and active_server_id is None
+                and active_host_id is None
+                and selected_namespaces is None
+            ):
+                started = self.create_chat(message, server_id=server_id)
+            else:
+                started = self.create_chat(
+                    message,
+                    server_id=server_id,
+                    server_ids=server_ids,
+                    active_server_id=active_server_id,
+                    active_host_id=active_host_id,
+                    selected_namespaces=selected_namespaces,
+                )
             try:
                 return int(started["chat_id"])
             except (KeyError, TypeError, ValueError) as error:
@@ -382,9 +459,22 @@ class SkyportalClient:
         server_id: Optional[int] = None,
         timeout: float = 300,
         poll_interval: float = 1,
+        *,
+        server_ids: Optional[List[int]] = None,
+        active_server_id: Optional[int] = None,
+        active_host_id: Optional[int] = None,
+        selected_namespaces: Optional[Dict[Any, List[str]]] = None,
     ) -> ChatTurnResult:
         """Start or continue a chat and wait for the resulting agent turn."""
-        chat_id = self.begin_chat_turn(message, chat_id=chat_id, server_id=server_id)
+        chat_id = self.begin_chat_turn(
+            message,
+            chat_id=chat_id,
+            server_id=server_id,
+            server_ids=server_ids,
+            active_server_id=active_server_id,
+            active_host_id=active_host_id,
+            selected_namespaces=selected_namespaces,
+        )
         return self.wait_for_chat(
             chat_id,
             after_sequence=after_sequence,

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -45,7 +45,10 @@ COMMANDS: Dict[str, CommandInfo] = {
         "Reattach to a chat (defaults to your previous one); --verbose replays its history",
     ),
     "/servers": CommandInfo("/servers", "List your Skyportal servers"),
-    "/server": CommandInfo("/server <id|auto>", "Select a server for agent execution"),
+    "/server": CommandInfo(
+        "/server <id> [id ...] | auto",
+        "Select one or more servers for agent execution",
+    ),
     "/clear": CommandInfo("/clear", "Clear the terminal"),
     "/about": CommandInfo("/about", "Show Skyportal CLI information"),
     "/exit": CommandInfo("/exit", "Leave Skyportal"),
@@ -115,6 +118,7 @@ class InteractiveShell:
         self.chat_id: Optional[int] = None
         self.last_sequence = 0
         self.selected_server_id: Optional[int] = None
+        self.selected_server_ids: List[int] = []
         self.previous_chat_id: Optional[int] = self._load_previous_chat_id()
         self._token_prompt = token_prompt or self._default_token_prompt
         self.session = session or self._create_prompt_session()
@@ -239,7 +243,12 @@ class InteractiveShell:
         ]
         if self.chat_id is not None:
             fragments.append(("class:context", " chat#{}".format(self.chat_id)))
-        if self.selected_server_id is not None:
+        if len(self.selected_server_ids) > 1:
+            fragments.append((
+                "class:context",
+                " servers#{}".format(",".join(str(value) for value in self.selected_server_ids)),
+            ))
+        elif self.selected_server_id is not None:
             fragments.append(("class:context", " server#{}".format(self.selected_server_id)))
         fragments.append(("class:arrow", "  > "))
         return fragments
@@ -353,6 +362,7 @@ class InteractiveShell:
         self.chat_id = None
         self.last_sequence = 0
         self.selected_server_id = None
+        self.selected_server_ids = []
         self._forget_chat()
         self.console.print("[green]✓ Local Skyportal credentials removed.[/green]")
 
@@ -419,11 +429,13 @@ class InteractiveShell:
             "#{}".format(self.chat_id) if self.chat_id is not None else "[dim]new chat[/dim]",
         )
         rows.add_row(
-            "Server",
-            str(self.selected_server_id)
-            if self.selected_server_id is not None
+            "Servers",
+            ", ".join(str(value) for value in self.selected_server_ids)
+            if self.selected_server_ids
             else "[dim]automatic[/dim]",
         )
+        if len(self.selected_server_ids) > 1:
+            rows.add_row("Default", str(self.selected_server_id))
         rows.add_row("Credentials", str(CredentialStore.get_path()))
         self._print_section("Session status", style="#3b82f6")
         self.console.print(rows)
@@ -512,31 +524,71 @@ class InteractiveShell:
                 ),
             )
         self.console.print(table)
-        self.console.print("[dim]Select one with /server <id>, or reset with /server auto.[/dim]")
+        self.console.print(
+            "[dim]Select one or more with /server <id> [id ...], "
+            "or reset with /server auto.[/dim]"
+        )
 
     def _cmd_server(self, args: List[str]) -> None:
-        if len(args) != 1:
-            self.console.print("[yellow]Usage:[/yellow] /server <id|auto>")
+        if not args:
+            self.console.print("[yellow]Usage:[/yellow] /server <id> [id ...] | auto")
             return
-        if args[0].lower() == "auto":
+        if len(args) == 1 and args[0].lower() == "auto":
+            if self.chat_id is not None:
+                with self.console.status("[cyan]Clearing server scope…[/cyan]", spinner="dots"):
+                    self.client.select_chat_servers(self.chat_id, [])
             self.selected_server_id = None
+            self.selected_server_ids = []
             self.console.print("[green]✓ Server selection set to automatic.[/green]")
             return
+        if any(argument.lower() == "auto" for argument in args):
+            self.console.print("[yellow]Use 'auto' by itself, or provide server IDs.[/yellow]")
+            return
         self._require_api_connection()
+        raw_ids = [part for argument in args for part in argument.split(",") if part]
         try:
-            server_id = int(args[0])
+            server_ids = list(dict.fromkeys(int(value) for value in raw_ids))
         except ValueError:
-            self.console.print("[yellow]Server ID must be a number or 'auto'.[/yellow]")
+            self.console.print("[yellow]Server IDs must be numbers, or use 'auto'.[/yellow]")
+            return
+        if not server_ids or any(server_id < 1 for server_id in server_ids):
+            self.console.print("[yellow]Server IDs must be positive numbers.[/yellow]")
             return
         if self.chat_id is not None:
-            with self.console.status("[cyan]Selecting server…[/cyan]", spinner="dots"):
-                self.client.select_chat_server(self.chat_id, server_id)
+            if len(server_ids) == 1:
+                # Keep the one-host path compatible with older website
+                # deployments that only expose /select-server/.
+                with self.console.status("[cyan]Selecting server…[/cyan]", spinner="dots"):
+                    self.client.select_chat_server(self.chat_id, server_ids[0])
+            else:
+                with self.console.status("[cyan]Selecting servers…[/cyan]", spinner="dots"):
+                    self.client.select_chat_servers(
+                        self.chat_id,
+                        server_ids,
+                        active_server_id=server_ids[0],
+                    )
         else:
             servers = self._items(self.client.servers())
-            if str(server_id) not in {str(server.get("id")) for server in servers}:
-                raise PortalError("Server {} was not found in your account".format(server_id))
-        self.selected_server_id = server_id
-        self.console.print("[green]✓ Server {} selected.[/green]".format(server_id))
+            available_ids = {str(server.get("id")) for server in servers}
+            missing = [server_id for server_id in server_ids if str(server_id) not in available_ids]
+            if missing:
+                raise PortalError(
+                    "Server{} {} {} not found in your account".format(
+                        "s" if len(missing) > 1 else "",
+                        ", ".join(str(server_id) for server_id in missing),
+                        "were" if len(missing) > 1 else "was",
+                    )
+                )
+        self.selected_server_ids = server_ids
+        self.selected_server_id = server_ids[0]
+        if len(server_ids) == 1:
+            message = "Server {} selected.".format(server_ids[0])
+        else:
+            message = "Servers {} selected; {} is the default.".format(
+                ", ".join(str(server_id) for server_id in server_ids),
+                server_ids[0],
+            )
+        self.console.print("[green]✓ {}[/green]".format(message))
 
     def _cmd_clear(self, args: List[str]) -> None:
         self.console.clear()
@@ -559,11 +611,19 @@ class InteractiveShell:
         self._require_api_connection()
         # Grab the chat ID before waiting so a Ctrl-C can cancel the turn
         # server-side, not just stop the shell from listening.
-        chat_id = self.client.begin_chat_turn(
-            message,
-            chat_id=self.chat_id,
-            server_id=self.selected_server_id,
-        )
+        if len(self.selected_server_ids) > 1:
+            chat_id = self.client.begin_chat_turn(
+                message,
+                chat_id=self.chat_id,
+                server_ids=self.selected_server_ids,
+                active_server_id=self.selected_server_id,
+            )
+        else:
+            chat_id = self.client.begin_chat_turn(
+                message,
+                chat_id=self.chat_id,
+                server_id=self.selected_server_id,
+            )
         self.chat_id = chat_id
         try:
             with self.console.status(

--- a/skyportalai/chat.py
+++ b/skyportalai/chat.py
@@ -54,6 +54,19 @@ class Chat:
     def select_server(self, server_id: int) -> None:
         self._client.chat.select_server(self.chat_id, server_id)
 
+    def select_servers(self, server_ids: list[int], *,
+                       active_server_id: int | None = None,
+                       active_host_id: int | None = None,
+                       selected_namespaces: dict[int | str, list[str]] | None = None) -> dict:
+        """Replace this chat's full multi-server execution scope."""
+        return self._client.chat.select_servers(
+            self.chat_id,
+            server_ids,
+            active_server_id=active_server_id,
+            active_host_id=active_host_id,
+            selected_namespaces=selected_namespaces,
+        )
+
     def cancel(self, reason: str | None = None) -> dict:
         return self._client.chat.cancel(self.chat_id, reason=reason)
 

--- a/skyportalai/cli/chat.py
+++ b/skyportalai/cli/chat.py
@@ -18,9 +18,40 @@ chat_app = typer.Typer(help="Create, inspect, approve, and cancel ops-agent chat
 def send(
     context: typer.Context,
     message: Annotated[str, typer.Argument(help="Instruction for the ops agent.")],
-    server_id: Annotated[
+    server_ids: Annotated[
+        list[int] | None,
+        typer.Option(
+            "--server",
+            "-s",
+            min=1,
+            help="Server ID for a new chat; repeat to set multi-host scope.",
+        ),
+    ] = None,
+    active_server_id: Annotated[
         int | None,
-        typer.Option("--server", help="Connected server ID for a new chat."),
+        typer.Option(
+            "--active-server",
+            min=1,
+            help="Default execution server; defaults to the first --server.",
+        ),
+    ] = None,
+    active_host_id: Annotated[
+        int | None,
+        typer.Option(
+            "--active-host",
+            min=1,
+            help="Terminal/Jupyter host; defaults to the active server for a new chat.",
+        ),
+    ] = None,
+    namespaces: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--namespace",
+            help=(
+                "Kubernetes scope as SERVER_ID=NAMESPACE; repeat as needed, "
+                "or use __all__ for cluster-wide scope."
+            ),
+        ),
     ] = None,
     chat_id: Annotated[
         int | None,
@@ -37,17 +68,73 @@ def send(
     ] = 1.0,
 ) -> None:
     """Start a chat or send a follow-up message."""
-    if chat_id is not None and server_id is not None:
+    selected_server_ids = list(dict.fromkeys(server_ids or []))
+    has_scope_options = bool(
+        selected_server_ids
+        or active_server_id is not None
+        or active_host_id is not None
+        or namespaces
+    )
+
+    if chat_id is not None and has_scope_options:
         state = _state(context)
-        state.output.failure("--server can only be used when creating a new chat.")
+        state.output.failure(
+            "--server can only be used when creating a new chat; --active-server, "
+            "--active-host, and --namespace are also creation-only."
+        )
         raise typer.Exit(2)
+    if not selected_server_ids and has_scope_options:
+        state = _state(context)
+        state.output.failure(
+            "--active-server, --active-host, and --namespace require at least one --server."
+        )
+        raise typer.Exit(2)
+
+    if selected_server_ids:
+        error = _scope_option_error(
+            selected_server_ids,
+            active_server_id=active_server_id,
+            active_host_id=active_host_id,
+            namespaces=namespaces or [],
+            clear_namespaces=False,
+            clear_scope=False,
+        )
+        if error is not None:
+            state = _state(context)
+            state.output.failure(error)
+            raise typer.Exit(2)
+
+    selected_namespaces = _parse_namespaces(namespaces or []) or None
+    effective_active_server_id = active_server_id
+    if effective_active_server_id is None and selected_server_ids:
+        effective_active_server_id = active_host_id or selected_server_ids[0]
+
+    # Keep the established one-host request intact for compatibility with
+    # deployments that predate atomic first-turn multi-host scope.
+    use_legacy_single_server = (
+        len(selected_server_ids) == 1
+        and active_server_id is None
+        and active_host_id is None
+        and selected_namespaces is None
+    )
 
     def operation(
         state: CLIContext,
     ) -> tuple[int, ChatStatus | None, MessagesPage | None, dict[str, Any]]:
         client = state.client()
         if chat_id is None:
-            chat = client.chat.create_chat(message, server_id=server_id)
+            if use_legacy_single_server:
+                chat = client.chat.create_chat(message, server_id=selected_server_ids[0])
+            elif selected_server_ids:
+                chat = client.chat.create_chat(
+                    message,
+                    server_ids=selected_server_ids,
+                    active_server_id=effective_active_server_id,
+                    active_host_id=active_host_id,
+                    selected_namespaces=selected_namespaces,
+                )
+            else:
+                chat = client.chat.create_chat(message)
             current_chat_id = chat.chat_id
             initial = dict(chat.raw)
         else:
@@ -184,6 +271,107 @@ def cancel(
     _state(context).output.success(result, human=f"Chat #{chat_id}: {result.get('status', 'cancelled')}")
 
 
+@chat_app.command("select-servers")
+def select_servers(
+    context: typer.Context,
+    chat_id: Annotated[int, typer.Argument(min=1)],
+    server_ids: Annotated[
+        list[int] | None,
+        typer.Option(
+            "--server",
+            "-s",
+            min=1,
+            help="Server ID to include in scope; repeat for multiple hosts.",
+        ),
+    ] = None,
+    active_server_id: Annotated[
+        int | None,
+        typer.Option(
+            "--active-server",
+            min=1,
+            help="Default execution server; defaults to the first --server.",
+        ),
+    ] = None,
+    active_host_id: Annotated[
+        int | None,
+        typer.Option(
+            "--active-host",
+            min=1,
+            help="Terminal/Jupyter host; omit to preserve its current binding.",
+        ),
+    ] = None,
+    namespaces: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--namespace",
+            help=(
+                "Kubernetes scope as SERVER_ID=NAMESPACE; repeat as needed, "
+                "or use __all__ for cluster-wide scope."
+            ),
+        ),
+    ] = None,
+    clear_namespaces: Annotated[
+        bool,
+        typer.Option("--clear-namespaces", help="Clear every Kubernetes namespace selection."),
+    ] = False,
+    clear_scope: Annotated[
+        bool,
+        typer.Option("--clear-scope", help="Explicitly clear every server from the chat scope."),
+    ] = False,
+) -> None:
+    """Replace the full multi-server scope of an existing chat."""
+    state = _state(context)
+    selected_server_ids = list(dict.fromkeys(server_ids or []))
+
+    error = _scope_option_error(
+        selected_server_ids,
+        active_server_id=active_server_id,
+        active_host_id=active_host_id,
+        namespaces=namespaces or [],
+        clear_namespaces=clear_namespaces,
+        clear_scope=clear_scope,
+    )
+    if error is not None:
+        state.output.failure(error)
+        raise typer.Exit(2)
+
+    selected_namespaces = (
+        {} if clear_namespaces else _parse_namespaces(namespaces or []) or None
+    )
+    effective_active_server_id = active_server_id
+    if effective_active_server_id is None and selected_server_ids:
+        effective_active_server_id = active_host_id or selected_server_ids[0]
+
+    def operation(cli_state: CLIContext) -> dict[str, Any]:
+        client = cli_state.client()
+        current = client.chat.get_status(chat_id)
+        if current.status in {"processing", "uninitialized", "awaiting_approval"}:
+            raise typer.BadParameter(
+                f"Chat #{chat_id} is {current.status}; finish the current turn or approval "
+                "before changing scope."
+            )
+        return client.chat.select_servers(
+            chat_id,
+            selected_server_ids,
+            active_server_id=effective_active_server_id,
+            active_host_id=active_host_id,
+            selected_namespaces=selected_namespaces,
+        )
+
+    try:
+        result = run_command(context, operation)
+    except typer.BadParameter as exc:
+        state.output.failure(str(exc))
+        raise typer.Exit(2) from None
+
+    scope = result.get("selected_server_ids", selected_server_ids)
+    shown_scope = ", ".join(str(server_id) for server_id in scope) or "cleared"
+    state.output.success(
+        result,
+        human=f"Chat #{chat_id} server scope: {shown_scope}",
+    )
+
+
 @chat_app.command("wait")
 def wait_for_chat(
     context: typer.Context,
@@ -211,6 +399,66 @@ def _messages_text(page: MessagesPage) -> str:
         f"[{message.sequence}] {message.role or 'unknown'}: {message.content}"
         for message in page.messages
     )
+
+
+def _scope_option_error(
+    server_ids: list[int],
+    *,
+    active_server_id: int | None,
+    active_host_id: int | None,
+    namespaces: list[str],
+    clear_namespaces: bool,
+    clear_scope: bool,
+) -> str | None:
+    selected = set(server_ids)
+    if clear_scope and selected:
+        return "--clear-scope cannot be combined with --server."
+    if not clear_scope and not selected:
+        return "Provide at least one --server or use --clear-scope."
+    if active_server_id is not None and active_server_id not in selected:
+        return "--active-server must also be included with --server."
+    if active_host_id is not None and active_host_id not in selected:
+        return "--active-host must also be included with --server."
+    if (
+        active_server_id is not None
+        and active_host_id is not None
+        and active_server_id != active_host_id
+    ):
+        return "--active-server and --active-host must match when both are provided."
+    if clear_namespaces and namespaces:
+        return "--clear-namespaces cannot be combined with --namespace."
+    try:
+        parsed = _parse_namespaces(namespaces)
+    except ValueError as exc:
+        return str(exc)
+    outside_scope = sorted(int(server_id) for server_id in parsed if int(server_id) not in selected)
+    if outside_scope:
+        return "Namespace server IDs must be included with --server: " + ", ".join(
+            str(server_id) for server_id in outside_scope
+        )
+    return None
+
+
+def _parse_namespaces(values: list[str]) -> dict[str, list[str]]:
+    parsed: dict[str, list[str]] = {}
+    for value in values:
+        server_text, separator, namespace = value.partition("=")
+        if not separator or not server_text or not namespace:
+            raise ValueError(
+                f"Invalid --namespace {value!r}; expected SERVER_ID=NAMESPACE."
+            )
+        try:
+            server_id = int(server_text)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid --namespace {value!r}; SERVER_ID must be a positive integer."
+            ) from exc
+        if server_id < 1:
+            raise ValueError(
+                f"Invalid --namespace {value!r}; SERVER_ID must be a positive integer."
+            )
+        parsed.setdefault(str(server_id), []).append(namespace)
+    return parsed
 
 
 def _exit_for_status(status: ChatStatus | None) -> None:

--- a/skyportalai/resources/chat.py
+++ b/skyportalai/resources/chat.py
@@ -36,10 +36,46 @@ class ChatResource:
 
     # -- lifecycle -----------------------------------------------------------
 
-    def create_chat(self, message: str, *, server_id: int | None = None) -> Chat:
-        """Create a chat and send the first message (agent starts processing)."""
+    def create_chat(
+        self,
+        message: str,
+        *,
+        server_id: int | None = None,
+        server_ids: list[int] | None = None,
+        active_server_id: int | None = None,
+        active_host_id: int | None = None,
+        selected_namespaces: dict[int | str, list[str]] | None = None,
+    ) -> Chat:
+        """Create a chat and send the first message (agent starts processing).
+
+        ``server_id`` is the backward-compatible single-server form.
+        ``server_ids`` selects the full multi-server scope atomically before
+        the first turn starts. The active ids and namespace scope are valid
+        only with ``server_ids``; mixing the plural and singular forms is
+        ambiguous and raises ``ValueError`` before making a request.
+        """
+        if server_id is not None and server_ids is not None:
+            raise ValueError("server_id and server_ids cannot be used together")
+        if server_ids is None and (
+            active_server_id is not None
+            or active_host_id is not None
+            or selected_namespaces is not None
+        ):
+            raise ValueError(
+                "server_ids is required with active_server_id, active_host_id, "
+                "or selected_namespaces"
+            )
+
         body: dict = {"message": message}
-        if server_id is not None:
+        if server_ids is not None:
+            body["selected_server_ids"] = list(server_ids)
+            if active_server_id is not None:
+                body["active_server_id"] = active_server_id
+            if active_host_id is not None:
+                body["active_host_id"] = active_host_id
+            if selected_namespaces is not None:
+                body["selected_namespaces"] = selected_namespaces
+        elif server_id is not None:
             body["server_id"] = server_id
         data = self._client._request("POST", "/api/v1/agent/chat/", json=body)
         return Chat(self._client, int(data.get("chat_id", 0) or 0), raw=dict(data))
@@ -103,6 +139,32 @@ class ChatResource:
         return self._client._request(
             "POST", f"/api/v1/agent/chat/{int(chat_id)}/select-server/",
             json={"server_id": server_id},
+        )
+
+    def select_servers(self, chat_id: int, server_ids: list[int], *,
+                       active_server_id: int | None = None,
+                       active_host_id: int | None = None,
+                       selected_namespaces: dict[int | str, list[str]] | None = None) -> dict:
+        """Replace a chat's full multi-server execution scope.
+
+        ``server_ids`` contains the account server IDs that the agent may use.
+        An empty list clears the scope. ``active_server_id`` chooses the
+        default execution target. Omitting ``active_host_id`` preserves the
+        terminal/Jupyter binding when possible, and omitting
+        ``selected_namespaces`` preserves namespace selections for servers
+        that remain in scope. Pass ``{}`` to clear all namespace selections;
+        ``["__all__"]`` selects every namespace on a Kubernetes server. Call
+        this between turns, while the chat is not actively processing.
+        """
+        body: dict = {"selected_server_ids": list(server_ids)}
+        if active_server_id is not None:
+            body["active_server_id"] = active_server_id
+        if active_host_id is not None:
+            body["active_host_id"] = active_host_id
+        if selected_namespaces is not None:
+            body["selected_namespaces"] = selected_namespaces
+        return self._client._request(
+            "POST", f"/api/v1/agent/chat/{int(chat_id)}/select-servers/", json=body,
         )
 
     def cancel(self, chat_id: int, *, reason: str | None = None) -> dict:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -50,6 +50,61 @@ def test_create_chat_omits_server_id_when_not_given(requests_mock):
     assert requests_mock.last_request.json() == {"message": "hello"}
 
 
+def test_create_chat_posts_atomic_multi_server_scope(requests_mock):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/",
+        status_code=202,
+        json={"chat_id": 1, "status": "processing"},
+    )
+
+    _client().chat.create_chat(
+        "compare the clusters",
+        server_ids=[9, 12],
+        active_server_id=9,
+        active_host_id=9,
+        selected_namespaces={12: ["default", "vllm"]},
+    )
+
+    assert requests_mock.last_request.json() == {
+        "message": "compare the clusters",
+        "selected_server_ids": [9, 12],
+        "active_server_id": 9,
+        "active_host_id": 9,
+        "selected_namespaces": {"12": ["default", "vllm"]},
+    }
+
+
+def test_create_chat_preserves_explicit_empty_multi_server_scope(requests_mock):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/",
+        status_code=202,
+        json={"chat_id": 1, "status": "processing"},
+    )
+
+    _client().chat.create_chat("work without a host", server_ids=[])
+
+    assert requests_mock.last_request.json() == {
+        "message": "work without a host",
+        "selected_server_ids": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"server_id": 9, "server_ids": [9]},
+        {"active_server_id": 9},
+        {"active_host_id": 9},
+        {"selected_namespaces": {}},
+    ],
+)
+def test_create_chat_rejects_ambiguous_scope_fields_before_request(requests_mock, kwargs):
+    with pytest.raises(ValueError):
+        _client().chat.create_chat("hello", **kwargs)
+
+    assert not requests_mock.called
+
+
 def test_send_message_posts_follow_up(requests_mock):
     requests_mock.post(f"{BASE}/api/v1/agent/chat/5/message/", status_code=202,
                        json={"status": "processing"})
@@ -131,6 +186,76 @@ def test_select_server_posts_id(requests_mock):
     result = _client().chat.select_server(5, 9)
     assert result == {"success": True, "server_id": 9}
     assert requests_mock.last_request.json() == {"server_id": 9}
+
+
+def test_select_servers_posts_server_ids_only_when_optionals_omitted(requests_mock):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/select-servers/",
+        json={"success": True, "selected_server_ids": [9, 12]},
+    )
+
+    result = _client().chat.select_servers(5, [9, 12])
+
+    assert result == {"success": True, "selected_server_ids": [9, 12]}
+    assert requests_mock.last_request.json() == {"selected_server_ids": [9, 12]}
+
+
+def test_select_servers_posts_all_optional_fields(requests_mock):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/select-servers/",
+        json={
+            "success": True,
+            "selected_server_ids": [9, 12],
+            "active_server_id": 9,
+            "active_host_id": 9,
+            "selected_namespaces": {"12": ["default"]},
+        },
+    )
+
+    result = _client().chat.select_servers(
+        5,
+        [9, 12],
+        active_server_id=9,
+        active_host_id=9,
+        selected_namespaces={"12": ["default"]},
+    )
+
+    assert result["selected_namespaces"] == {"12": ["default"]}
+    assert requests_mock.last_request.json() == {
+        "selected_server_ids": [9, 12],
+        "active_server_id": 9,
+        "active_host_id": 9,
+        "selected_namespaces": {"12": ["default"]},
+    }
+
+
+def test_chat_select_servers_delegates_with_bound_chat_id(requests_mock):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/select-servers/",
+        json={"success": True, "selected_server_ids": [9]},
+    )
+    chat = Chat(_client(), 5)
+
+    chat.select_servers([9], selected_namespaces={9: ["__all__"]})
+
+    assert requests_mock.last_request.json() == {
+        "selected_server_ids": [9],
+        "selected_namespaces": {"9": ["__all__"]},
+    }
+
+
+def test_select_servers_can_clear_scope_and_namespaces(requests_mock):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/select-servers/",
+        json={"success": True, "selected_server_ids": [], "selected_namespaces": {}},
+    )
+
+    _client().chat.select_servers(5, [], selected_namespaces={})
+
+    assert requests_mock.last_request.json() == {
+        "selected_server_ids": [],
+        "selected_namespaces": {},
+    }
 
 
 def test_cancel_posts_optional_reason(requests_mock):

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -20,8 +20,27 @@ class FakeChatResource:
         self.calls = []
         self.wait_status = ChatStatus(status="idle")
 
-    def create_chat(self, message, *, server_id=None):
-        self.calls.append(("create_chat", message, server_id))
+    def create_chat(
+        self,
+        message,
+        *,
+        server_id=None,
+        server_ids=None,
+        active_server_id=None,
+        active_host_id=None,
+        selected_namespaces=None,
+    ):
+        self.calls.append(
+            (
+                "create_chat",
+                message,
+                server_id,
+                server_ids,
+                active_server_id,
+                active_host_id,
+                selected_namespaces,
+            )
+        )
         return SimpleNamespace(chat_id=42, raw={"status": "processing"})
 
     def send_message(self, chat_id, message):
@@ -51,6 +70,33 @@ class FakeChatResource:
     def cancel(self, chat_id, *, reason):
         self.calls.append(("cancel", chat_id, reason))
         return {"success": True, "status": "cancelled"}
+
+    def select_servers(
+        self,
+        chat_id,
+        server_ids,
+        *,
+        active_server_id=None,
+        active_host_id=None,
+        selected_namespaces=None,
+    ):
+        self.calls.append(
+            (
+                "select_servers",
+                chat_id,
+                server_ids,
+                active_server_id,
+                active_host_id,
+                selected_namespaces,
+            )
+        )
+        return {
+            "success": True,
+            "selected_server_ids": server_ids,
+            "active_server_id": active_server_id,
+            "active_host_id": active_host_id,
+            "selected_namespaces": selected_namespaces or {},
+        }
 
 
 @pytest.fixture
@@ -84,7 +130,7 @@ def test_send_wait_targets_server_and_returns_json(fake_client):
 
     assert result.exit_code == 0
     assert fake_client.chat.calls == [
-        ("create_chat", "edit the file", 7),
+        ("create_chat", "edit the file", 7, None, None, None, None),
         ("wait", 42, 12.0, 0.0),
         ("get_messages", 42, 0, 100),
     ]
@@ -98,8 +144,68 @@ def test_send_without_wait_does_not_fetch_messages(fake_client):
     result = runner.invoke(app, ["--json", "chat", "send", "inspect", "--server", "7"])
 
     assert result.exit_code == 0
-    assert fake_client.chat.calls == [("create_chat", "inspect", 7)]
+    assert fake_client.chat.calls == [
+        ("create_chat", "inspect", 7, None, None, None, None)
+    ]
     assert json.loads(result.stdout)["data"]["messages"] == []
+
+
+def test_send_creates_first_turn_with_atomic_multi_host_scope(fake_client):
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "chat",
+            "send",
+            "compare the clusters",
+            "--server",
+            "7",
+            "--server",
+            "9",
+            "--server",
+            "7",
+            "--namespace",
+            "9=default",
+            "--namespace",
+            "9=vllm",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls == [
+        (
+            "create_chat",
+            "compare the clusters",
+            None,
+            [7, 9],
+            7,
+            None,
+            {"9": ["default", "vllm"]},
+        )
+    ]
+
+
+def test_send_uses_explicit_active_host_as_first_turn_default(fake_client):
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "chat",
+            "send",
+            "inspect",
+            "--server",
+            "7",
+            "--server",
+            "9",
+            "--active-host",
+            "9",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls == [
+        ("create_chat", "inspect", None, [7, 9], 9, 9, None)
+    ]
 
 
 def test_send_follow_up_rejects_server_option(fake_client):
@@ -111,6 +217,39 @@ def test_send_follow_up_rejects_server_option(fake_client):
     assert result.exit_code == 2
     assert fake_client.chat.calls == []
     assert "--server can only" in json.loads(result.stderr)["error"]
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (["--active-server", "7"], "require at least one --server"),
+        (["--server", "7", "--active-server", "9"], "--active-server"),
+        (
+            [
+                "--server",
+                "7",
+                "--server",
+                "9",
+                "--active-server",
+                "7",
+                "--active-host",
+                "9",
+            ],
+            "must match",
+        ),
+        (["--server", "7", "--namespace", "9=default"], "included with --server"),
+        (["--server", "7", "--namespace", "bad"], "SERVER_ID=NAMESPACE"),
+    ],
+)
+def test_send_rejects_invalid_first_turn_scope(fake_client, arguments, message):
+    result = runner.invoke(
+        app,
+        ["--json", "chat", "send", "inspect", *arguments],
+    )
+
+    assert result.exit_code == 2
+    assert fake_client.chat.calls == []
+    assert message in json.loads(result.stderr)["error"]
 
 
 def test_status_awaiting_approval_uses_actionable_exit_code(fake_client):
@@ -151,6 +290,145 @@ def test_mutating_commands_are_thin_sdk_wrappers(fake_client, arguments, expecte
 
     assert result.exit_code == 0
     assert fake_client.chat.calls == [expected]
+
+
+def test_select_servers_sets_multi_host_and_namespace_scope(fake_client):
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "chat",
+            "select-servers",
+            "42",
+            "--server",
+            "9",
+            "--server",
+            "12",
+            "--active-server",
+            "9",
+            "--namespace",
+            "12=default",
+            "--namespace",
+            "12=vllm",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls == [
+        ("get_status", 42),
+        ("select_servers", 42, [9, 12], 9, None, {"12": ["default", "vllm"]}),
+    ]
+    assert json.loads(result.stdout)["data"]["selected_server_ids"] == [9, 12]
+
+
+def test_select_servers_can_clear_scope_and_namespaces(fake_client):
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "chat",
+            "select-servers",
+            "42",
+            "--clear-scope",
+            "--clear-namespaces",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls == [
+        ("get_status", 42),
+        ("select_servers", 42, [], None, None, {}),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        ([], "at least one --server"),
+        (["--server", "9", "--clear-scope"], "cannot be combined"),
+        (["--server", "9", "--active-server", "12"], "--active-server"),
+        (["--server", "9", "--namespace", "12=default"], "included with --server"),
+        (["--server", "9", "--namespace", "bad"], "SERVER_ID=NAMESPACE"),
+        (
+            ["--server", "9", "--namespace", "9=default", "--clear-namespaces"],
+            "cannot be combined",
+        ),
+    ],
+)
+def test_select_servers_rejects_invalid_scope_options(fake_client, arguments, message):
+    result = runner.invoke(
+        app,
+        ["--json", "chat", "select-servers", "42", *arguments],
+    )
+
+    assert result.exit_code == 2
+    assert fake_client.chat.calls == []
+    assert message in json.loads(result.stderr)["error"]
+
+
+def test_select_servers_refuses_to_rescope_a_processing_chat(fake_client):
+    fake_client.chat.wait_status = ChatStatus(status="processing")
+
+    result = runner.invoke(
+        app,
+        ["--json", "chat", "select-servers", "42", "--server", "9"],
+    )
+
+    assert result.exit_code == 2
+    assert fake_client.chat.calls == [("get_status", 42)]
+    assert "finish the current turn" in json.loads(result.stderr)["error"]
+
+
+def test_select_servers_defaults_active_server_to_first_deduplicated_id(fake_client):
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "chat",
+            "select-servers",
+            "42",
+            "--server",
+            "9",
+            "--server",
+            "12",
+            "--server",
+            "9",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls == [
+        ("get_status", 42),
+        ("select_servers", 42, [9, 12], 9, None, None),
+    ]
+
+
+def test_select_servers_refuses_to_rescope_while_approval_is_pending(fake_client):
+    fake_client.chat.wait_status = ChatStatus(status="awaiting_approval")
+
+    result = runner.invoke(
+        app,
+        ["--json", "chat", "select-servers", "42", "--server", "9"],
+    )
+
+    assert result.exit_code == 2
+    assert fake_client.chat.calls == [("get_status", 42)]
+    assert "approval" in json.loads(result.stderr)["error"]
+
+
+def test_select_servers_allows_rescope_while_chat_awaits_input(fake_client):
+    fake_client.chat.wait_status = ChatStatus(status="awaiting_input")
+
+    result = runner.invoke(
+        app,
+        ["--json", "chat", "select-servers", "42", "--server", "9"],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls == [
+        ("get_status", 42),
+        ("select_servers", 42, [9], 9, None, None),
+    ]
 
 
 def test_sdk_errors_are_clean_json_without_traceback(fake_client, monkeypatch):

--- a/tests/test_legacy_cli_multihost.py
+++ b/tests/test_legacy_cli_multihost.py
@@ -1,0 +1,47 @@
+"""Click CLI coverage for first-turn multi-server scope."""
+
+from click.testing import CliRunner
+
+from skyportal.cli import main
+from skyportal.portal import ChatTurnResult
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def run_chat_turn(self, message, **kwargs):
+        self.calls.append((message, kwargs))
+        return ChatTurnResult(42, "idle", [], [], 0)
+
+    @staticmethod
+    def assistant_text(_messages):
+        return ""
+
+
+def test_ask_repeated_server_options_scope_the_first_turn(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr("skyportal.cli._portal_client", lambda: client)
+
+    result = CliRunner().invoke(
+        main,
+        ["ask", "compare hosts", "--server", "7", "--server", "9", "--server", "7"],
+    )
+
+    assert result.exit_code == 0
+    assert client.calls == [
+        (
+            "compare hosts",
+            {"server_ids": [7, 9], "active_server_id": 7},
+        )
+    ]
+
+
+def test_ask_one_server_preserves_the_legacy_singular_request(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr("skyportal.cli._portal_client", lambda: client)
+
+    result = CliRunner().invoke(main, ["ask", "check host", "--server", "7"])
+
+    assert result.exit_code == 0
+    assert client.calls == [("check host", {"server_id": 7})]

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -231,6 +231,38 @@ def test_create_chat_posts_message_and_optional_server(credential_path):
     assert json.loads(request.data) == {"message": "Check GPU health", "server_id": 7}
 
 
+def test_create_chat_posts_atomic_multi_server_scope(credential_path):
+    CredentialStore.save(
+        {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
+    )
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch(
+        "skyportal.portal.urlopen",
+        return_value=FakeResponse({"chat_id": 42, "status": "processing"}),
+    ) as call:
+        client.create_chat(
+            "Compare hosts",
+            server_ids=[7, 9, 7],
+            selected_namespaces={9: ["default"]},
+        )
+
+    request = call.call_args.args[0]
+    assert json.loads(request.data) == {
+        "message": "Compare hosts",
+        "selected_server_ids": [7, 9],
+        "active_server_id": 7,
+        "selected_namespaces": {"9": ["default"]},
+    }
+
+
+def test_create_chat_rejects_singular_and_plural_server_options(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with pytest.raises(PortalError, match="not both"):
+        client.create_chat("Compare hosts", server_id=7, server_ids=[7, 9])
+
+
 def test_follow_up_message_uses_existing_chat(credential_path):
     CredentialStore.save(
         {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
@@ -395,6 +427,45 @@ def test_approval_and_server_selection_use_headless_endpoints(credential_path):
     assert json.loads(server_request.data) == {"server_id": 7}
 
 
+def test_multi_server_selection_uses_plural_headless_endpoint(credential_path):
+    CredentialStore.save(
+        {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
+    )
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch("skyportal.portal.urlopen", return_value=FakeResponse({"success": True})) as call:
+        client.select_chat_servers(
+            42,
+            [7, 9, 7],
+            selected_namespaces={9: ["__all__"]},
+        )
+
+    request = call.call_args.args[0]
+    assert request.full_url.endswith("/api/v1/agent/chat/42/select-servers/")
+    assert json.loads(request.data) == {
+        "selected_server_ids": [7, 9],
+        "active_server_id": 7,
+        "selected_namespaces": {"9": ["__all__"]},
+    }
+
+
+@pytest.mark.parametrize(
+    "scope_kwargs",
+    [
+        {"active_server_id": 7},
+        {"active_host_id": 7},
+        {"selected_namespaces": {7: ["default"]}},
+    ],
+)
+def test_create_chat_rejects_plural_scope_fields_without_server_ids(
+    credential_path, scope_kwargs
+):
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with pytest.raises(PortalError, match="server_ids is required"):
+        client.create_chat("check host", **scope_kwargs)
+
+
 def test_assistant_text_uses_newest_assistant_message(credential_path):
     messages = [
         {"sequence": 2, "role": "assistant", "content": [{"type": "text", "text": "old"}]},
@@ -435,6 +506,27 @@ def test_begin_chat_turn_creates_new_chat(credential_path):
         chat_id = client.begin_chat_turn("hello", server_id=3)
     assert chat_id == 77
     create.assert_called_once_with("hello", server_id=3)
+
+
+def test_begin_chat_turn_creates_new_chat_with_multi_server_scope(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    with patch.object(client, "create_chat", return_value={"chat_id": 77}) as create:
+        chat_id = client.begin_chat_turn(
+            "hello",
+            server_ids=[3, 4],
+            active_server_id=4,
+            selected_namespaces={4: ["default"]},
+        )
+
+    assert chat_id == 77
+    create.assert_called_once_with(
+        "hello",
+        server_id=None,
+        server_ids=[3, 4],
+        active_server_id=4,
+        active_host_id=None,
+        selected_namespaces={4: ["default"]},
+    )
 
 
 def test_begin_chat_turn_continues_existing_chat(credential_path):

--- a/tests/test_shell_multihost.py
+++ b/tests/test_shell_multihost.py
@@ -1,0 +1,161 @@
+"""Interactive-shell coverage for multi-server chat scope."""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from skyportal.portal import ChatTurnResult, PortalError
+from skyportal.shell import InteractiveShell
+
+
+class FakeClient:
+    def __init__(self):
+        self.base_url = "https://app.skyportal.ai"
+        self.scope_calls = []
+        self.single_scope_calls = []
+        self.begin_calls = []
+
+    def is_authenticated(self):
+        return True
+
+    def servers(self):
+        return [
+            {"id": 7, "hostname": "gpu-7"},
+            {"id": 9, "hostname": "gpu-9"},
+        ]
+
+    def select_chat_servers(
+        self,
+        chat_id,
+        server_ids,
+        *,
+        active_server_id=None,
+        active_host_id=None,
+        selected_namespaces=None,
+    ):
+        self.scope_calls.append(
+            (
+                chat_id,
+                server_ids,
+                active_server_id,
+                active_host_id,
+                selected_namespaces,
+            )
+        )
+        return {"success": True, "selected_server_ids": server_ids}
+
+    def select_chat_server(self, chat_id, server_id):
+        self.single_scope_calls.append((chat_id, server_id))
+        return {"success": True, "server_id": server_id}
+
+    def begin_chat_turn(
+        self,
+        message,
+        chat_id=None,
+        server_id=None,
+        *,
+        server_ids=None,
+        active_server_id=None,
+    ):
+        self.begin_calls.append(
+            (message, chat_id, server_id, server_ids, active_server_id)
+        )
+        return chat_id if chat_id is not None else 100
+
+    def wait_for_chat(self, chat_id, after_sequence=0):
+        return ChatTurnResult(chat_id, "idle", [], [], after_sequence)
+
+
+@pytest.fixture
+def shell(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    client = FakeClient()
+    console = Console(file=StringIO(), force_terminal=False, width=100)
+    instance = InteractiveShell(
+        console=console,
+        client_factory=lambda: client,
+        session=object(),
+        token_prompt=lambda _prompt: "",
+    )
+    return instance, client, console
+
+
+def test_multi_server_scope_is_sent_atomically_with_first_turn(shell):
+    instance, client, console = shell
+
+    instance._cmd_server(["7", "9", "7"])
+    instance._send_prompt("compare every selected host")
+
+    assert instance.selected_server_ids == [7, 9]
+    assert instance.selected_server_id == 7
+    assert client.scope_calls == []
+    assert client.begin_calls == [
+        ("compare every selected host", None, None, [7, 9], 7),
+    ]
+    assert "Servers 7, 9 selected; 7 is the default" in console.file.getvalue()
+    assert "servers#7,9" in "".join(part[1] for part in instance._prompt_fragments())
+
+
+def test_multi_server_scope_updates_existing_chat(shell):
+    instance, client, _console = shell
+    instance.chat_id = 42
+
+    instance._cmd_server(["7,9"])
+
+    assert client.scope_calls == [(42, [7, 9], 7, None, None)]
+    assert instance.selected_server_ids == [7, 9]
+
+
+def test_single_server_first_turn_preserves_legacy_singular_request(shell):
+    instance, client, _console = shell
+
+    instance._cmd_server(["7"])
+    instance._send_prompt("check this host")
+
+    assert client.scope_calls == []
+    assert client.begin_calls == [("check this host", None, 7, None, None)]
+
+
+def test_single_server_existing_chat_uses_legacy_singular_endpoint(shell):
+    instance, client, _console = shell
+    instance.chat_id = 42
+
+    instance._cmd_server(["7"])
+
+    assert client.single_scope_calls == [(42, 7)]
+    assert client.scope_calls == []
+    assert instance.selected_server_ids == [7]
+
+
+def test_auto_explicitly_clears_existing_chat_scope(shell):
+    instance, client, console = shell
+    instance.chat_id = 42
+    instance.selected_server_ids = [7, 9]
+    instance.selected_server_id = 7
+
+    instance._cmd_server(["auto"])
+
+    assert client.scope_calls == [(42, [], None, None, None)]
+    assert instance.selected_server_ids == []
+    assert instance.selected_server_id is None
+    assert "automatic" in console.file.getvalue()
+
+
+def test_new_chat_scope_rejects_unowned_server(shell):
+    instance, _client, _console = shell
+
+    with pytest.raises(PortalError, match="Server 11 was not found"):
+        instance._cmd_server(["7", "11"])
+
+    assert instance.selected_server_ids == []
+
+
+@pytest.mark.parametrize("arguments", [[], ["auto", "7"], ["bad"], ["0"]])
+def test_invalid_multi_server_syntax_does_not_change_scope(shell, arguments):
+    instance, client, _console = shell
+
+    instance._cmd_server(arguments)
+
+    assert instance.selected_server_ids == []
+    assert client.scope_calls == []


### PR DESCRIPTION
## Summary

Describe the problem and the approach taken.

## Validation

- [ ] Tests added or updated where behavior changed
- [ ] `poetry run pytest` passes
- [ ] `poetry run ruff check .` passes
- [ ] Public API/configuration changes are documented
- [ ] No credentials or private run data are included

## Related issue

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-server chat selection across the interactive shell, CLI, and SDK.
  * Added support for active server/host selection and per-server namespace scoping.
  * Added commands to update or clear server scope during an existing chat.
  * Repeatable `--server` options now support multi-server automation workflows.
  * Preserved compatibility with single-server chat commands and SDK usage.

* **Documentation**
  * Expanded setup, SDK, automation, and architecture guidance for multi-server workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->