### PR TITLE
Implemented Kubernetes support and issue #3114 across both repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,31 @@ Use `--clear-scope` to remove every selected server explicitly.
 
 Run `skyportalai --help` for the complete command reference.
 
+## Kubernetes clusters
+
+Connect a cluster with its kubeconfig. The CLI sends the credential only to the
+authenticated SkyPortal API, where the same validation and encrypted storage as
+the web application are used; kubeconfigs are never returned by lifecycle APIs.
+
+```bash
+skyportalai kubernetes connect production --kubeconfig ~/.kube/config --environment Production
+skyportalai kubernetes list
+```
+
+Use the returned cluster ID as a normal chat target. Namespace scope is an
+allowlist and every mutating command keeps the existing approval gate:
+
+```bash
+skyportalai chat send --server 17 --namespace 17=default --wait \
+  "Restart the api deployment and verify the rollout"
+```
+
+Remove the stored cluster credential when it is no longer needed:
+
+```bash
+skyportalai kubernetes disconnect 17
+```
+
 ## Observability agent
 
 Install the collector dependencies and review the deployment guide before

--- a/skyportalai/__init__.py
+++ b/skyportalai/__init__.py
@@ -13,6 +13,7 @@ from .chat import Chat
 from .types import (
     ApprovalResult,
     ChatStatus,
+    KubernetesCluster,
     Message,
     MessagesPage,
     PendingApproval,
@@ -24,6 +25,7 @@ __all__ = [
     "User",
     "Chat",
     "ChatStatus",
+    "KubernetesCluster",
     "PendingApproval",
     "ApprovalResult",
     "Message",

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -196,11 +196,16 @@ class Skyportal:
     @staticmethod
     def _handle_response(response: requests.Response) -> Any:
         if 200 <= response.status_code < 300:
-            if response.status_code == 204 or not response.content:
+            if response.status_code in (204, 205):
                 return {}
+            if not response.content:
+                raise APIError(
+                    "API returned an empty response body.",
+                    status_code=response.status_code,
+                    body=response.text,
+                )
             try:
                 return response.json()
-            except ValueError as exc:
                 raise APIError(
                     "API returned a non-JSON response.",
                     status_code=response.status_code,

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -197,6 +197,7 @@ class Skyportal:
     def _handle_response(response: requests.Response) -> Any:
         if 200 <= response.status_code < 300:
             if response.status_code in (204, 205):
+                response.close()
                 return {}
             if not response.content:
                 raise APIError(

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -206,6 +206,7 @@ class Skyportal:
                 )
             try:
                 return response.json()
+            except ValueError as exc:
                 raise APIError(
                     "API returned a non-JSON response.",
                     status_code=response.status_code,

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -17,6 +17,7 @@ from ._exceptions import (
 )
 from ._version import __version__
 from .resources.chat import ChatResource
+from .resources.kubernetes import KubernetesResource
 from .resources.me import fetch_me
 from .types import User
 
@@ -151,6 +152,7 @@ class Skyportal:
         self._backoff_base = 0.5
 
         self.chat = ChatResource(self)
+        self.kubernetes = KubernetesResource(self)
 
     def _request(self, method: str, path: str, *, params: dict | None = None,
                  json: object = None) -> Any:

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -196,6 +196,8 @@ class Skyportal:
     @staticmethod
     def _handle_response(response: requests.Response) -> Any:
         if 200 <= response.status_code < 300:
+            if response.status_code == 204 or not response.content:
+                return {}
             try:
                 return response.json()
             except ValueError as exc:

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -40,7 +40,7 @@ def _read_kubeconfig(path: str) -> str:
         try:
             contents = raw_bytes.decode("utf-8")
         except UnicodeDecodeError as exc:
-            raise typer.BadParameter(f"Cannot read kubeconfig {resolved}: {exc}") from None
+            raise typer.BadParameter(f"Cannot decode kubeconfig {resolved}: {exc}") from None
         source = str(resolved)
     if not contents.strip():
         raise typer.BadParameter(f"Kubeconfig from {source} is empty.")
@@ -74,9 +74,12 @@ def connect(
             environment=environment,
         ),
     )
-    verification = (
-        "verified" if cluster.connection_verified else "saved; reachability not verified"
-    )
+    if cluster.connection_verified is True:
+        verification = "verified"
+    elif cluster.connection_verified is False:
+        verification = "saved; reachability not verified"
+    else:
+        verification = "saved; reachability unknown"
     _state(context).output.success(
         cluster,
         human=(

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -67,7 +67,7 @@ def connect(
     """Validate, encrypt, and connect a Kubernetes cluster."""
     name = name.strip()
     if not name:
-        raise typer.BadParameter("Cluster name cannot be empty.", param_hint="'NAME'")
+        raise typer.BadParameter("Cluster name cannot be empty.", param_hint="NAME")
     contents = _read_kubeconfig(kubeconfig)
     cluster = run_command(
         context,

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -25,14 +25,15 @@ def _read_kubeconfig(path: str) -> str:
     else:
         resolved = Path(path).expanduser()
         try:
-            size = resolved.stat().st_size
+            with resolved.open("rb") as fh:
+                raw_bytes = fh.read(_MAX_KUBECONFIG_BYTES + 1)
         except OSError as exc:
             raise typer.BadParameter(f"Cannot read kubeconfig {resolved}: {exc}") from None
-        if size > _MAX_KUBECONFIG_BYTES:
+        if len(raw_bytes) > _MAX_KUBECONFIG_BYTES:
             raise typer.BadParameter("Kubeconfig exceeds the 1 MiB safety limit.")
         try:
-            contents = resolved.read_text(encoding="utf-8")
-        except (OSError, UnicodeError) as exc:
+            contents = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
             raise typer.BadParameter(f"Cannot read kubeconfig {resolved}: {exc}") from None
         source = str(resolved)
     if len(contents.encode("utf-8")) > _MAX_KUBECONFIG_BYTES:
@@ -111,8 +112,12 @@ def disconnect(
     ] = False,
 ) -> None:
     """Remove a Kubernetes cluster and its encrypted kubeconfig from SkyPortal."""
-    if not yes and not typer.confirm(f"Disconnect Kubernetes cluster #{cluster_id}?"):
-        raise typer.Abort()
+    if not yes:
+        if _state(context).output.json_mode:
+            _state(context).output.failure("--yes is required when using --json mode")
+            raise typer.Exit(1)
+        if not typer.confirm(f"Disconnect Kubernetes cluster #{cluster_id}?"):
+            raise typer.Abort()
     result = run_command(
         context,
         lambda state: state.client().kubernetes.disconnect(cluster_id),

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -65,6 +65,9 @@ def connect(
     ] = "Custom",
 ) -> None:
     """Validate, encrypt, and connect a Kubernetes cluster."""
+    name = name.strip()
+    if not name:
+        raise typer.BadParameter("Cluster name cannot be empty.", param_hint="'NAME'")
     contents = _read_kubeconfig(kubeconfig)
     cluster = run_command(
         context,

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -20,7 +20,13 @@ _MAX_KUBECONFIG_BYTES = 1024 * 1024
 
 def _read_kubeconfig(path: str) -> str:
     if path == "-":
-        contents = sys.stdin.read(_MAX_KUBECONFIG_BYTES + 1)
+        raw_bytes = sys.stdin.buffer.read(_MAX_KUBECONFIG_BYTES + 1)
+        if len(raw_bytes) > _MAX_KUBECONFIG_BYTES:
+            raise typer.BadParameter("Kubeconfig exceeds the 1 MiB safety limit.")
+        try:
+            contents = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise typer.BadParameter(f"Cannot decode kubeconfig from stdin: {exc}") from None
         source = "stdin"
     else:
         resolved = Path(path).expanduser()
@@ -36,8 +42,6 @@ def _read_kubeconfig(path: str) -> str:
         except UnicodeDecodeError as exc:
             raise typer.BadParameter(f"Cannot read kubeconfig {resolved}: {exc}") from None
         source = str(resolved)
-    if len(contents.encode("utf-8")) > _MAX_KUBECONFIG_BYTES:
-        raise typer.BadParameter("Kubeconfig exceeds the 1 MiB safety limit.")
     if not contents.strip():
         raise typer.BadParameter(f"Kubeconfig from {source} is empty.")
     return contents

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -1,0 +1,123 @@
+"""Kubernetes lifecycle commands for the public CLI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from .context import get_state as _state
+from .context import run_command
+
+kubernetes_app = typer.Typer(
+    help="Connect Kubernetes clusters and make them available to agent chats."
+)
+
+_MAX_KUBECONFIG_BYTES = 1024 * 1024
+
+
+def _read_kubeconfig(path: str) -> str:
+    if path == "-":
+        contents = sys.stdin.read(_MAX_KUBECONFIG_BYTES + 1)
+        source = "stdin"
+    else:
+        resolved = Path(path).expanduser()
+        try:
+            size = resolved.stat().st_size
+        except OSError as exc:
+            raise typer.BadParameter(f"Cannot read kubeconfig {resolved}: {exc}") from None
+        if size > _MAX_KUBECONFIG_BYTES:
+            raise typer.BadParameter("Kubeconfig exceeds the 1 MiB safety limit.")
+        try:
+            contents = resolved.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise typer.BadParameter(f"Cannot read kubeconfig {resolved}: {exc}") from None
+        source = str(resolved)
+    if len(contents.encode("utf-8")) > _MAX_KUBECONFIG_BYTES:
+        raise typer.BadParameter("Kubeconfig exceeds the 1 MiB safety limit.")
+    if not contents.strip():
+        raise typer.BadParameter(f"Kubeconfig from {source} is empty.")
+    return contents
+
+
+@kubernetes_app.command("connect")
+def connect(
+    context: typer.Context,
+    name: Annotated[str, typer.Argument(help="Display name for the cluster.")],
+    kubeconfig: Annotated[
+        str,
+        typer.Option(
+            "--kubeconfig",
+            "-k",
+            help="Kubeconfig path, or '-' to read it from standard input.",
+        ),
+    ] = "~/.kube/config",
+    environment: Annotated[
+        str,
+        typer.Option("--environment", "-e", help="Environment policy label."),
+    ] = "Custom",
+) -> None:
+    """Validate, encrypt, and connect a Kubernetes cluster."""
+    contents = _read_kubeconfig(kubeconfig)
+    cluster = run_command(
+        context,
+        lambda state: state.client().kubernetes.connect(
+            name,
+            contents,
+            environment=environment,
+        ),
+    )
+    verification = (
+        "verified" if cluster.connection_verified else "saved; reachability not verified"
+    )
+    _state(context).output.success(
+        cluster,
+        human=(
+            f"Connected Kubernetes cluster #{cluster.id}: {cluster.name} "
+            f"({cluster.environment}, {verification})\n"
+            f"Control it with: skyportalai chat send --server {cluster.id} "
+            f"--namespace {cluster.id}=default --wait \"get the pods\""
+        ),
+    )
+
+
+@kubernetes_app.command("list")
+def list_clusters(context: typer.Context) -> None:
+    """List Kubernetes clusters connected to the account."""
+    clusters = run_command(context, lambda state: state.client().kubernetes.list())
+    if not clusters:
+        human = "No Kubernetes clusters connected."
+    else:
+        lines = ["ID  NAME  STATUS  ENVIRONMENT  NAMESPACES"]
+        for cluster in clusters:
+            namespaces = ",".join(cluster.namespaces) or "-"
+            lines.append(
+                f"{cluster.id}  {cluster.name}  {cluster.status or '-'}  "
+                f"{cluster.environment}  {namespaces}"
+            )
+        human = "\n".join(lines)
+    _state(context).output.success(clusters, human=human)
+
+
+@kubernetes_app.command("disconnect")
+def disconnect(
+    context: typer.Context,
+    cluster_id: Annotated[int, typer.Argument(min=1, help="Cluster ID to remove.")],
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+) -> None:
+    """Remove a Kubernetes cluster and its encrypted kubeconfig from SkyPortal."""
+    if not yes and not typer.confirm(f"Disconnect Kubernetes cluster #{cluster_id}?"):
+        raise typer.Abort()
+    result = run_command(
+        context,
+        lambda state: state.client().kubernetes.disconnect(cluster_id),
+    )
+    _state(context).output.success(
+        result,
+        human=f"Disconnected Kubernetes cluster #{cluster_id}.",
+    )

--- a/skyportalai/cli/main.py
+++ b/skyportalai/cli/main.py
@@ -105,8 +105,10 @@ def set_config(
 
 
 from .chat import chat_app  # noqa: E402
+from .kubernetes import kubernetes_app  # noqa: E402
 
 app.add_typer(chat_app, name="chat")
+app.add_typer(kubernetes_app, name="kubernetes")
 
 
 def main() -> None:

--- a/skyportalai/resources/kubernetes.py
+++ b/skyportalai/resources/kubernetes.py
@@ -1,0 +1,59 @@
+"""Kubernetes cluster lifecycle resource."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..types import KubernetesCluster
+
+if TYPE_CHECKING:
+    from .._client import Skyportal
+
+
+class KubernetesResource:
+    """Connect, list, and disconnect Kubernetes clusters.
+
+    Kubeconfigs are sent only to the authenticated SkyPortal API, where the
+    existing server-side validation and encrypted-storage path handles them.
+    No lifecycle response returns kubeconfig credential material.
+    """
+
+    def __init__(self, client: "Skyportal"):
+        self._client = client
+
+    def list(self) -> list[KubernetesCluster]:
+        data = self._client._request("GET", "/api/v1/infrastructure/kubernetes/")
+        return [
+            KubernetesCluster.from_dict(item)
+            for item in data.get("clusters", [])
+            if isinstance(item, dict)
+        ]
+
+    def connect(
+        self,
+        name: str,
+        kubeconfig: str,
+        *,
+        environment: str = "Custom",
+    ) -> KubernetesCluster:
+        name = name.strip()
+        kubeconfig = kubeconfig.strip()
+        environment = environment.strip() or "Custom"
+        if not name:
+            raise ValueError("name cannot be empty")
+        if not kubeconfig:
+            raise ValueError("kubeconfig cannot be empty")
+        data = self._client._request(
+            "POST",
+            "/api/v1/infrastructure/kubernetes/",
+            json={"name": name, "environment": environment, "kubeconfig": kubeconfig},
+        )
+        return KubernetesCluster.from_dict(data.get("cluster") or {})
+
+    def disconnect(self, cluster_id: int) -> dict:
+        if cluster_id <= 0:
+            raise ValueError("cluster_id must be a positive integer")
+        return self._client._request(
+            "DELETE",
+            f"/api/v1/infrastructure/kubernetes/{cluster_id}/",
+        )

--- a/skyportalai/resources/kubernetes.py
+++ b/skyportalai/resources/kubernetes.py
@@ -51,7 +51,7 @@ class KubernetesResource:
         return KubernetesCluster.from_dict(data.get("cluster") or {})
 
     def disconnect(self, cluster_id: int) -> dict:
-        if cluster_id <= 0:
+        if isinstance(cluster_id, bool) or not isinstance(cluster_id, int) or cluster_id <= 0:
             raise ValueError("cluster_id must be a positive integer")
         return self._client._request(
             "DELETE",

--- a/skyportalai/resources/kubernetes.py
+++ b/skyportalai/resources/kubernetes.py
@@ -25,7 +25,7 @@ class KubernetesResource:
         data = self._client._request("GET", "/api/v1/infrastructure/kubernetes/")
         return [
             KubernetesCluster.from_dict(item)
-            for item in data.get("clusters", [])
+            for item in data.get("clusters") or []
             if isinstance(item, dict)
         ]
 

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -44,7 +44,7 @@ class KubernetesCluster:
             status=str(data.get("status") or ""),
             api_endpoint=str(data.get("api_endpoint") or ""),
             namespaces=[str(item) for item in (ns_raw if isinstance(ns_raw, list) else [])],
-            connection_verified=bool(verified) if verified is not None else None,
+            connection_verified=verified if isinstance(verified, bool) else (bool(verified) if isinstance(verified, int) else None),
             raw={key: value for key, value in data.items() if key != "kubeconfig"},
         )
 

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -44,7 +44,7 @@ class KubernetesCluster:
             api_endpoint=str(data.get("api_endpoint") or ""),
             namespaces=[str(item) for item in data.get("namespaces", [])],
             connection_verified=bool(verified) if verified is not None else None,
-            raw=dict(data),
+            raw={key: value for key, value in data.items() if key != "kubeconfig"},
         )
 
 

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -44,7 +44,10 @@ class KubernetesCluster:
             status=str(data.get("status") or ""),
             api_endpoint=str(data.get("api_endpoint") or ""),
             namespaces=[str(item) for item in (ns_raw if isinstance(ns_raw, list) else [])],
-            connection_verified=verified if isinstance(verified, bool) else (bool(verified) if isinstance(verified, int) else None),
+            connection_verified=(
+                verified if isinstance(verified, bool)
+                else (bool(verified) if isinstance(verified, int) and verified in (0, 1) else None)
+            ),
             raw={key: value for key, value in data.items() if key != "kubeconfig"},
         )
 

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -21,6 +21,34 @@ class User:
 
 
 @dataclass(frozen=True)
+class KubernetesCluster:
+    """A Kubernetes cluster connected to the authenticated SkyPortal account."""
+
+    id: int
+    name: str
+    environment: str = "Custom"
+    status: str = ""
+    api_endpoint: str = ""
+    namespaces: list[str] = field(default_factory=list)
+    connection_verified: bool | None = None
+    raw: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "KubernetesCluster":
+        verified = data.get("connection_verified")
+        return cls(
+            id=int(data.get("id", 0) or 0),
+            name=str(data.get("name") or data.get("hostname") or ""),
+            environment=str(data.get("environment") or data.get("host_type") or "Custom"),
+            status=str(data.get("status") or ""),
+            api_endpoint=str(data.get("api_endpoint") or ""),
+            namespaces=[str(item) for item in data.get("namespaces", [])],
+            connection_verified=bool(verified) if verified is not None else None,
+            raw=dict(data),
+        )
+
+
+@dataclass(frozen=True)
 class PendingApproval:
     """An approval the agent is blocked on (bash command or plan)."""
 

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -36,13 +36,14 @@ class KubernetesCluster:
     @classmethod
     def from_dict(cls, data: dict) -> "KubernetesCluster":
         verified = data.get("connection_verified")
+        ns_raw = data.get("namespaces")
         return cls(
             id=int(data.get("id", 0) or 0),
             name=str(data.get("name") or data.get("hostname") or ""),
             environment=str(data.get("environment") or data.get("host_type") or "Custom"),
             status=str(data.get("status") or ""),
             api_endpoint=str(data.get("api_endpoint") or ""),
-            namespaces=[str(item) for item in data.get("namespaces") or []],
+            namespaces=[str(item) for item in (ns_raw if isinstance(ns_raw, list) else [])],
             connection_verified=bool(verified) if verified is not None else None,
             raw={key: value for key, value in data.items() if key != "kubeconfig"},
         )

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -42,7 +42,7 @@ class KubernetesCluster:
             environment=str(data.get("environment") or data.get("host_type") or "Custom"),
             status=str(data.get("status") or ""),
             api_endpoint=str(data.get("api_endpoint") or ""),
-            namespaces=[str(item) for item in data.get("namespaces", [])],
+            namespaces=[str(item) for item in data.get("namespaces") or []],
             connection_verified=bool(verified) if verified is not None else None,
             raw={key: value for key, value in data.items() if key != "kubeconfig"},
         )

--- a/tests/test_cli_kubernetes.py
+++ b/tests/test_cli_kubernetes.py
@@ -72,3 +72,12 @@ def test_list_and_disconnect(monkeypatch, tmp_path):
     assert listed.exit_code == 0
     assert removed.exit_code == 0
     assert resource.calls == [("list",), ("disconnect", 9)]
+
+
+def test_disconnect_json_mode_requires_yes(monkeypatch, tmp_path):
+    _fake_client(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["--json", "kubernetes", "disconnect", "9"])
+
+    assert result.exit_code != 0
+    parsed = json.loads(result.output if result.output.strip() else "{}")
+    assert parsed.get("ok") is False

--- a/tests/test_cli_kubernetes.py
+++ b/tests/test_cli_kubernetes.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from skyportalai.cli.context import CLIContext
+from skyportalai.cli.main import app
+from skyportalai.types import KubernetesCluster
+
+runner = CliRunner()
+
+
+class FakeKubernetesResource:
+    def __init__(self):
+        self.calls = []
+
+    def connect(self, name, kubeconfig, *, environment):
+        self.calls.append(("connect", name, kubeconfig, environment))
+        return KubernetesCluster(
+            id=9,
+            name=name,
+            environment=environment,
+            status="connected",
+            connection_verified=True,
+        )
+
+    def list(self):
+        self.calls.append(("list",))
+        return [KubernetesCluster(id=9, name="prod", namespaces=["default"])]
+
+    def disconnect(self, cluster_id):
+        self.calls.append(("disconnect", cluster_id))
+        return {"success": True, "cluster_id": cluster_id}
+
+
+def _fake_client(monkeypatch, tmp_path):
+    monkeypatch.setenv("SKYPORTAL_CONFIG_PATH", str(tmp_path / "config.yaml"))
+    monkeypatch.setenv("SKYPORTAL_CREDENTIALS_PATH", str(tmp_path / "credentials.json"))
+    monkeypatch.setenv("SKYPORTAL_API_KEY", "sk-test")
+    resource = FakeKubernetesResource()
+    monkeypatch.setattr(
+        CLIContext,
+        "client",
+        lambda self: SimpleNamespace(kubernetes=resource),
+    )
+    return resource
+
+
+def test_connect_reads_file_and_never_prints_kubeconfig(monkeypatch, tmp_path):
+    resource = _fake_client(monkeypatch, tmp_path)
+    config = tmp_path / "config"
+    config.write_text("apiVersion: v1\nkind: Config\nclusters: []\nsecret: do-not-print")
+
+    result = runner.invoke(
+        app,
+        ["--json", "kubernetes", "connect", "prod", "-k", str(config), "-e", "Production"],
+    )
+
+    assert result.exit_code == 0
+    assert resource.calls[0][0:2] == ("connect", "prod")
+    assert "do-not-print" not in result.output
+    assert json.loads(result.stdout)["data"]["id"] == 9
+
+
+def test_list_and_disconnect(monkeypatch, tmp_path):
+    resource = _fake_client(monkeypatch, tmp_path)
+    listed = runner.invoke(app, ["--json", "kubernetes", "list"])
+    removed = runner.invoke(app, ["--json", "kubernetes", "disconnect", "9", "--yes"])
+
+    assert listed.exit_code == 0
+    assert removed.exit_code == 0
+    assert resource.calls == [("list",), ("disconnect", 9)]

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -90,7 +90,7 @@ def test_connect_redacts_kubeconfig_from_raw(requests_mock):
 
 def test_disconnect_rejects_boolean_and_non_integer_ids():
     client = _client()
-    for bad_id in (True, False, 1.5, "1"):
+    for bad_id in (True, False, 0, -1, 1.5, "1"):
         try:
             client.kubernetes.disconnect(bad_id)
         except ValueError:

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -61,3 +61,39 @@ def test_lifecycle_validates_empty_values_without_network():
             pass
         else:
             raise AssertionError("expected ValueError")
+
+
+def test_connect_redacts_kubeconfig_from_raw(requests_mock):
+    """Server echo of kubeconfig must not appear in the raw field."""
+    requests_mock.post(
+        "https://api.test/api/v1/infrastructure/kubernetes/",
+        json={
+            "success": True,
+            "cluster": {
+                "id": 5,
+                "name": "staging",
+                "environment": "Staging",
+                "status": "connected",
+                "connection_verified": True,
+                "namespaces": [],
+                "kubeconfig": "SENSITIVE_CREDENTIAL",
+            },
+        },
+        status_code=201,
+    )
+
+    cluster = _client().kubernetes.connect("staging", "apiVersion: v1", environment="Staging")
+
+    assert "kubeconfig" not in cluster.raw
+    assert "SENSITIVE_CREDENTIAL" not in str(cluster.raw)
+
+
+def test_disconnect_rejects_boolean_and_non_integer_ids():
+    client = _client()
+    for bad_id in (True, False, 1.5, "1"):
+        try:
+            client.kubernetes.disconnect(bad_id)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"expected ValueError for cluster_id={bad_id!r}")

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -1,0 +1,63 @@
+from skyportalai import KubernetesCluster
+from skyportalai._client import Skyportal
+
+
+def _client():
+    return Skyportal(api_key="sk-test", base_url="https://api.test")
+
+
+def test_connect_sends_kubeconfig_without_returning_it(requests_mock):
+    requests_mock.post(
+        "https://api.test/api/v1/infrastructure/kubernetes/",
+        json={
+            "success": True,
+            "cluster": {
+                "id": 17,
+                "name": "prod",
+                "environment": "Production",
+                "target_kind": "kubernetes",
+                "status": "connected",
+                "connection_verified": True,
+                "namespaces": ["default"],
+            },
+        },
+        status_code=201,
+    )
+
+    cluster = _client().kubernetes.connect(
+        "prod",
+        "apiVersion: v1\nkind: Config\nclusters: []",
+        environment="Production",
+    )
+
+    assert isinstance(cluster, KubernetesCluster)
+    assert cluster.id == 17
+    assert cluster.connection_verified is True
+    sent = requests_mock.last_request.json()
+    assert sent["kubeconfig"].startswith("apiVersion")
+
+
+def test_list_and_disconnect(requests_mock):
+    requests_mock.get(
+        "https://api.test/api/v1/infrastructure/kubernetes/",
+        json={"clusters": [{"id": 17, "name": "prod", "namespaces": ["default", "vllm"]}]},
+    )
+    requests_mock.delete(
+        "https://api.test/api/v1/infrastructure/kubernetes/17/",
+        json={"success": True, "cluster_id": 17},
+    )
+
+    client = _client()
+    assert client.kubernetes.list()[0].namespaces == ["default", "vllm"]
+    assert client.kubernetes.disconnect(17)["success"] is True
+
+
+def test_lifecycle_validates_empty_values_without_network():
+    client = _client()
+    for name, config in (("", "config"), ("prod", "")):
+        try:
+            client.kubernetes.connect(name, config)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError")

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -97,3 +97,13 @@ def test_disconnect_rejects_boolean_and_non_integer_ids():
             pass
         else:
             raise AssertionError(f"expected ValueError for cluster_id={bad_id!r}")
+
+
+def test_disconnect_handles_204_no_content(requests_mock):
+    """A 204 No Content disconnect response must not raise an error."""
+    requests_mock.delete(
+        "https://api.test/api/v1/infrastructure/kubernetes/17/",
+        status_code=204,
+    )
+    result = _client().kubernetes.disconnect(17)
+    assert result == {}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -8,6 +8,7 @@ def test_public_exports_present():
         "User",
         "Chat",
         "ChatStatus",
+        "KubernetesCluster",
         "PendingApproval",
         "ApprovalResult",
         "Message",

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -46,6 +46,14 @@ def test_404_raises_api_error(requests_mock):
     assert exc.value.status_code == 404
 
 
+def test_200_non_json_raises_api_error(requests_mock):
+    requests_mock.get("https://api.test/ping", status_code=200, text="not json")
+    with pytest.raises(APIError) as exc:
+        _client()._request("GET", "/ping")
+    assert exc.value.status_code == 200
+    assert exc.value.body == "not json"
+
+
 def test_5xx_retried_then_raises(requests_mock):
     requests_mock.get("https://api.test/ping", status_code=503, json={})
     with pytest.raises(APIError) as exc:


### PR DESCRIPTION
## Change type

Select **all** that apply and fill in the corresponding section(s) below.
Sections whose type is **not** checked may be left as-is.

- [ ] 🆕 New or changed CLI command / flag
- [x] 🔄 Behavior change (observable difference for users)
- [ ] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

Describe the problem and the approach taken.

---

<!-- ✅ Required when "New or changed CLI command / flag" is checked -->
## CLI usage example

> **Required for new/changed commands or flags.**
> Show the command(s) as a user would type them, including representative
> options, and note which documentation page was updated.

```
# before (omit if this is a brand-new command)
kubernetes was not reachable

# after
now kubernetes works
```

Docs updated: <!-- path(s) or "N/A – no public docs affected" -->

---

<!-- ✅ Required when "Behavior change" is checked -->
## Before / after

> **Required for behavior changes.**
> Describe what users experienced before and what they experience after.

**Before:** no kubernetes

**After:** kubernetes

Test coverage: added tests

---

<!-- ✅ Required when "Security-sensitive change" is checked -->
## Security callout

> **Required for auth, credentials, kubeconfig, or secrets handling.**
> Explain the threat model impact of this change.

**What changed in security-sensitive code:**

**Why it is safe / how the risk is mitigated:**

**Credentials or secrets introduced:** None <!-- or describe and justify -->

---

<!-- ✅ Standard checklist – always complete this section -->
## Validation

- [ ] Tests added or updated where behavior changed
- [ ] `poetry run pytest` passes
- [ ] `poetry run ruff check .` passes
- [ ] Public API/configuration changes are documented
- [ ] No credentials or private run data are included

## Related issue

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes cluster lifecycle management to the SDK and CLI (connect, list, disconnect).
  * Introduced a top-level `KubernetesCluster` type with connection status, environment, namespaces, and verification details.
  * Added README documentation for connecting clusters, using cluster IDs as chat targets, and disconnecting to remove stored credentials.
* **Bug Fixes**
  * Improved handling of empty HTTP responses (e.g., `204 No Content`).
  * Enforced stricter kubeconfig validation and safer disconnection behavior (including requiring `--yes` in JSON mode).
* **Tests**
  * Expanded unit and CLI test coverage for lifecycle operations, input validation, kubeconfig redaction, and `204` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->