### PR TITLE
Add permission mode handling and improve chat functionality in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Useful commands:
 /login          Connect your Skyportal account
 /servers        List available infrastructure
 /server <id> [id ...]  Select one or more servers; the first is the default
+/permission [ask|autoapprove]  Show or change the shared approval setting
 /status         Show the active context
 /new            Start a new investigation
 /resume         Continue the previous investigation
@@ -78,13 +79,22 @@ Use the SDK when you want to start or automate an investigation from Python:
 from skyportalai import Skyportal
 
 with Skyportal(api_key="sk-...") as client:
+    client.set_permission_mode("autoapprove")
     chat = client.chat.create_chat(
         "What changed before GPU utilization dropped?",
         server_id=12,
     )
-    result = chat.wait(on_approval=lambda approval: True)
+    result = chat.wait()
     print(result.status)
 ```
+
+`ask` is the default. `autoapprove` submits each concrete approval through the
+normal audited approval endpoint; it does not bypass read-only environments,
+server scope, repository denials, or other backend safety policy. An explicit
+`on_approval` callback takes precedence over the stored account setting. Waits
+are indefinite by default so long-running single-host, multi-host, and
+Kubernetes turns can finish; pass `timeout=` when an automation job needs a
+finite deadline.
 
 To make the full multi-host scope available to the first turn, create the chat
 with repeatable server scope and an active default:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,11 +35,19 @@ an unexpected origin or sent in cleartext.
 ## Conversation flow
 
 1. The first message calls `POST /api/v1/agent/chat/` and stores the returned chat ID.
-2. The CLI polls `GET /api/v1/agent/chat/{id}/status/` with a bounded timeout.
-3. It fetches new messages from `GET /api/v1/agent/chat/{id}/messages/` using the last sequence as a cursor.
+2. The CLI polls `GET /api/v1/agent/chat/{id}/status/` until the turn settles;
+   a finite timeout is opt-in for automation.
+3. While it polls, it fetches and renders new messages from
+   `GET /api/v1/agent/chat/{id}/messages/` using the last sequence as a cursor.
 4. Follow-up messages call `POST /api/v1/agent/chat/{id}/message/`.
 5. If status is `awaiting_approval`, the CLI shows the requested action and submits the user's decision to the approval endpoint.
 6. `/new` clears only local chat context and starts a new chat on the next message.
+
+`/permission ask|autoapprove` reads or replaces the account-wide approval
+preference shared with the website and public SDK. Autoapproval still sends one
+typed decision at a time and waits for the durable checkpoint to advance before
+submitting another. Backend read-only, target scope, repository, and environment
+policy are always rechecked.
 
 ## Server context
 

--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -20,6 +20,13 @@ PRODUCTION_MARKETING_URL = "https://skyportal.ai"
 PRODUCTION_APP_URL = "https://app.skyportal.ai"
 CLI_USER_AGENT = f"Skyportal-CLI/{__version__} (+https://app.skyportal.ai)"
 
+_BUSY_CHAT_STATUSES = {"processing", "uninitialized"}
+_IMMEDIATE_CHAT_STATUSES = {"awaiting_approval", "error"}
+_PERMISSION_MODES = frozenset({"ask", "autoapprove"})
+_TERMINAL_MESSAGE_SETTLEMENT_ATTEMPTS = 5
+_TERMINAL_MESSAGE_SETTLEMENT_INITIAL_DELAY = 0.25
+_TERMINAL_MESSAGE_SETTLEMENT_MAX_DELAY = 2.0
+
 
 class _NoRedirectHandler(HTTPRedirectHandler):
     """Keep Bearer credentials from being forwarded through HTTP redirects."""
@@ -37,9 +44,15 @@ urlopen = build_opener(_NoRedirectHandler).open
 class PortalError(RuntimeError):
     """Raised when communication with Skyportal fails."""
 
-    def __init__(self, message: str, status_code: Optional[int] = None):
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        code: Optional[str] = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
+        self.code = code
 
 
 @dataclass(frozen=True)
@@ -216,6 +229,29 @@ class SkyportalClient:
         """Remove the stored GitHub Personal Access Token from the server."""
         self._request("DELETE", "/api/v1/agent/github-token/delete/")
 
+    def get_permission_mode(self) -> str:
+        """Return the account's shared agent-approval mode."""
+        payload = self._request("GET", "/api/v1/agent/permission/")
+        return self._parse_permission_mode(payload)
+
+    def set_permission_mode(self, mode: str) -> str:
+        """Persist ``ask`` or ``autoapprove`` for the authenticated account."""
+        if mode not in _PERMISSION_MODES:
+            raise PortalError("Permission mode must be 'ask' or 'autoapprove'")
+        payload = self._request(
+            "PUT",
+            "/api/v1/agent/permission/",
+            json_body={"permission_mode": mode},
+        )
+        return self._parse_permission_mode(payload)
+
+    @staticmethod
+    def _parse_permission_mode(payload: Any) -> str:
+        mode = payload.get("permission_mode") if isinstance(payload, dict) else None
+        if mode not in _PERMISSION_MODES:
+            raise PortalError("Skyportal returned an invalid permission mode")
+        return str(mode)
+
     def agents(self) -> List[Dict[str, str]]:
         """Describe the single Skyportal ReAct agent."""
         return [{"id": "skyportal", "name": "Skyportal Agent", "status": "ready"}]
@@ -274,6 +310,13 @@ class SkyportalClient:
         """Get current headless workflow status."""
         return self._request("GET", "/api/v1/agent/chat/{}/status/".format(chat_id))
 
+    def get_execution_status(self, chat_id: int) -> Dict[str, Any]:
+        """Get detailed execution state for an explicit status inspection."""
+        return self._request(
+            "GET",
+            "/api/v1/agent/chat/{}/execution-status/".format(chat_id),
+        )
+
     def chat_messages(self, chat_id: int, after_sequence: int = 0) -> Dict[str, Any]:
         """Get messages created after the supplied sequence cursor."""
         query = urlencode({"after_sequence": after_sequence, "limit": 500})
@@ -287,6 +330,8 @@ class SkyportalClient:
         chat_id: int,
         approval: Dict[str, Any],
         decision: str,
+        *,
+        autoapproved: bool = False,
     ) -> Dict[str, Any]:
         """Approve or reject one pending headless-agent action."""
         approval_id = quote(str(approval.get("approval_id", "")), safe="")
@@ -296,6 +341,8 @@ class SkyportalClient:
         }
         if approval.get("command"):
             body["command"] = approval["command"]
+        if autoapproved:
+            body["autoapproved"] = True
         return self._request(
             "POST",
             "/api/v1/agent/chat/{}/approve/{}/".format(chat_id, approval_id),
@@ -340,64 +387,136 @@ class SkyportalClient:
         self,
         chat_id: int,
         after_sequence: int = 0,
-        timeout: float = 300,
+        timeout: Optional[float] = None,
         poll_interval: float = 1,
+        on_progress: Optional[Callable[[List[Dict[str, Any]]], None]] = None,
     ) -> ChatTurnResult:
-        """Poll a headless chat until it completes, pauses, or fails."""
-        deadline = time.monotonic() + timeout
-        state: Dict[str, Any] = {"status": "processing", "pending_approvals": []}
-        while time.monotonic() < deadline:
-            state = self.chat_status(chat_id)
-            if state.get("status") not in ("processing", "uninitialized"):
-                break
-            time.sleep(poll_interval)
-        else:
-            raise PortalError(
-                "Skyportal is still working after {} seconds. Chat #{} remains available.".format(
-                    int(timeout), chat_id
-                )
-            )
+        """Poll a headless chat until it completes, pauses, or fails.
 
-        # chat_status() reporting a terminal status doesn't guarantee the
-        # message(s) that status is about are queryable yet — reproduced
-        # live: a fast, LLM-free turn (e.g. one host-collection step) can
-        # flip status to "awaiting_input" and still lose the race against a
-        # single immediate chat_messages() call, which then comes back
-        # empty even though the turn produced a real response. A browser
-        # polling continuously never hits this (it just picks the message
-        # up on the next tick); a one-shot fetch here needs to keep trying
-        # instead of reporting "no response" for a response that exists
-        # but isn't visible yet. How long that takes varies (near-instant
-        # for most turns, longer under load), so this backs off up to 2s
-        # between attempts and keeps going until the SAME deadline already
-        # governing the status poll above — not a separate fixed budget —
-        # rather than guessing a fixed number of retries that could still
-        # be too short some of the time and wasted work the rest.
-        valid_messages: List[Dict[str, Any]] = []
-        messages_retry_delay = 0.25
+        While the workflow is busy, persisted messages are fetched alongside
+        its lightweight status. ``on_progress`` receives each newly observed
+        message batch at most once. The returned result retains all observed
+        messages regardless of callback delivery, and ``latest_sequence``
+        covers that complete set so renderers can deduplicate by sequence. The
+        timeout is an idle deadline and is extended by a new message batch or
+        a real workflow-status transition. ``None`` disables that deadline.
+        """
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        state: Dict[str, Any] = {"status": "processing", "pending_approvals": []}
+        previous_status: Optional[str] = None
+        latest_sequence = after_sequence
+        result_messages: List[Dict[str, Any]] = []
+
+        def fetch_new_messages(*, deliver_progress: bool) -> tuple[List[Dict[str, Any]], bool]:
+            """Fetch, order, and record messages strictly beyond the local cursor."""
+            nonlocal deadline, latest_sequence
+
+            payload = self.chat_messages(chat_id, after_sequence=latest_sequence)
+            raw_messages = payload.get("messages", []) if isinstance(payload, dict) else []
+            sequenced: List[tuple[int, Dict[str, Any]]] = []
+            for message in raw_messages if isinstance(raw_messages, list) else []:
+                if not isinstance(message, dict):
+                    continue
+                try:
+                    sequence = int(message.get("sequence"))
+                except (TypeError, ValueError):
+                    continue
+                if sequence > latest_sequence:
+                    sequenced.append((sequence, message))
+
+            batch: List[Dict[str, Any]] = []
+            batch_sequences = set()
+            for sequence, message in sorted(sequenced, key=lambda item: item[0]):
+                if sequence in batch_sequences:
+                    continue
+                batch_sequences.add(sequence)
+                batch.append(message)
+
+            if batch:
+                latest_sequence = max(batch_sequences)
+                if timeout is not None:
+                    deadline = time.monotonic() + timeout
+
+                result_messages.extend(batch)
+                if deliver_progress and on_progress is not None:
+                    try:
+                        on_progress(batch)
+                    except Exception:
+                        # Progress rendering is additive and the complete
+                        # batch remains available in the final result.
+                        pass
+
+            has_more = bool(payload.get("has_more")) if isinstance(payload, dict) else False
+            return batch, has_more
+
         while True:
-            payload = self.chat_messages(chat_id, after_sequence=after_sequence)
-            messages = payload.get("messages", []) if isinstance(payload, dict) else []
-            valid_messages = [message for message in messages if isinstance(message, dict)]
-            if valid_messages or time.monotonic() >= deadline:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise PortalError(
+                    "Skyportal has made no progress for {} seconds. Chat #{} remains available.".format(
+                        int(timeout), chat_id
+                    )
+                )
+
+            state = self.chat_status(chat_id)
+            status = str(state.get("status", "unknown"))
+            if (
+                timeout is not None
+                and previous_status is not None
+                and status != previous_status
+            ):
+                deadline = time.monotonic() + timeout
+            previous_status = status
+
+            if status not in _BUSY_CHAT_STATUSES:
                 break
-            time.sleep(messages_retry_delay)
-            messages_retry_delay = min(messages_retry_delay * 2, 2.0)
-        sequences = [after_sequence]
-        for message in valid_messages:
-            try:
-                sequences.append(int(message.get("sequence", 0)))
-            except (TypeError, ValueError):
-                continue
+
+            while True:
+                batch, has_more = fetch_new_messages(deliver_progress=True)
+                if not has_more or not batch:
+                    break
+            time.sleep(poll_interval)
+
+        # Approval and error states already contain the information the caller
+        # needs to act. One persisted-message fetch is useful context, but a
+        # consistency-settlement delay would only make the prompt/error noisy.
+        if status in _IMMEDIATE_CHAT_STATUSES:
+            fetch_new_messages(deliver_progress=False)
+        else:
+            # A terminal status write can win a short race with its final
+            # persisted message. Settle that race with a small fixed budget
+            # independent of the (possibly disabled or exhausted) idle timeout.
+            settlement_delay = _TERMINAL_MESSAGE_SETTLEMENT_INITIAL_DELAY
+            messages_seen_before_terminal = bool(result_messages)
+            for attempt in range(_TERMINAL_MESSAGE_SETTLEMENT_ATTEMPTS):
+                batch, has_more = fetch_new_messages(deliver_progress=False)
+                if batch:
+                    while has_more:
+                        next_batch, has_more = fetch_new_messages(deliver_progress=False)
+                        if not next_batch:
+                            break
+                    break
+                # Earlier rows can be only the user's own prompt or an
+                # intermediate thought/tool call. Always allow one short
+                # retry after an empty terminal fetch so those rows cannot
+                # suppress the final assistant-message settlement entirely.
+                if messages_seen_before_terminal and attempt >= 1:
+                    break
+                if attempt + 1 < _TERMINAL_MESSAGE_SETTLEMENT_ATTEMPTS:
+                    time.sleep(settlement_delay)
+                    settlement_delay = min(
+                        settlement_delay * 2,
+                        _TERMINAL_MESSAGE_SETTLEMENT_MAX_DELAY,
+                    )
+
         pending = state.get("pending_approvals", [])
         if not isinstance(pending, list):
             pending = []
         return ChatTurnResult(
             chat_id=chat_id,
-            status=str(state.get("status", "unknown")),
-            messages=valid_messages,
+            status=status,
+            messages=result_messages,
             pending_approvals=[item for item in pending if isinstance(item, dict)],
-            latest_sequence=max(sequences),
+            latest_sequence=latest_sequence,
         )
 
     def begin_chat_turn(
@@ -457,8 +576,9 @@ class SkyportalClient:
         chat_id: Optional[int] = None,
         after_sequence: int = 0,
         server_id: Optional[int] = None,
-        timeout: float = 300,
+        timeout: Optional[float] = None,
         poll_interval: float = 1,
+        on_progress: Optional[Callable[[List[Dict[str, Any]]], None]] = None,
         *,
         server_ids: Optional[List[int]] = None,
         active_server_id: Optional[int] = None,
@@ -480,6 +600,7 @@ class SkyportalClient:
             after_sequence=after_sequence,
             timeout=timeout,
             poll_interval=poll_interval,
+            on_progress=on_progress,
         )
 
     @staticmethod
@@ -575,8 +696,10 @@ class SkyportalClient:
                         status_code=status,
                     ) from error
         except HTTPError as error:
+            code = None
             try:
                 payload = json.loads(error.read().decode())
+                code = payload.get("code") if isinstance(payload, dict) else None
                 message = (
                     payload.get("error_description")
                     or payload.get("error")
@@ -588,6 +711,9 @@ class SkyportalClient:
             raise PortalError(
                 str(message) if message else "Skyportal request failed ({})".format(error.code),
                 status_code=error.code,
+                code=str(code) if code else None,
             ) from error
         except URLError as error:
             raise PortalError("Could not connect to Skyportal: {}".format(error.reason)) from error
+        except TimeoutError as error:
+            raise PortalError("Could not connect to Skyportal: request timed out") from error

--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -453,7 +453,7 @@ class SkyportalClient:
             if deadline is not None and time.monotonic() >= deadline:
                 raise PortalError(
                     "Skyportal has made no progress for {} seconds. Chat #{} remains available.".format(
-                        int(timeout), chat_id
+                        f"{timeout:g}", chat_id
                     )
                 )
 

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -2,7 +2,9 @@
 
 import json
 import os
+import re
 import shlex
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -20,6 +22,15 @@ from rich.table import Table
 from rich.text import Text
 
 from skyportal.portal import ChatTurnResult, CredentialStore, PortalError, SkyportalClient
+
+_PERMISSION_MODES = frozenset({"ask", "autoapprove"})
+_AUTOAPPROVE_TYPES = frozenset({"", "bash_command", "plan"})
+_APPROVAL_SETTLEMENT_TIMEOUT = 300.0
+_APPROVAL_SETTLEMENT_POLL_INTERVAL = 0.25
+
+
+class _AutoapprovalPolicyConflict(RuntimeError):
+    """The shared mode changed between its GET and marked approval POST."""
 
 
 @dataclass(frozen=True)
@@ -39,6 +50,10 @@ COMMANDS: Dict[str, CommandInfo] = {
         "/github-token <set|status|remove>", "Manage the GitHub PAT used for git clone"
     ),
     "/status": CommandInfo("/status", "Show connection, chat, and server status"),
+    "/permission": CommandInfo(
+        "/permission [autoapprove|ask]",
+        "Show or change the shared account approval policy",
+    ),
     "/new": CommandInfo("/new", "Start a fresh Skyportal chat"),
     "/resume": CommandInfo(
         "/resume [chat_id] [--verbose]",
@@ -86,6 +101,11 @@ class SkyportalCompleter(Completer):
                 ("status", "show whether a PAT is saved"),
                 ("remove", "delete the saved PAT"),
             )
+        elif command == "/permission":
+            options = (
+                ("autoapprove", "approve supported pending actions automatically"),
+                ("ask", "prompt before each gated action"),
+            )
         for value, metadata in options:
             if value.startswith(word.lower()):
                 yield Completion(value, start_position=-len(word), display_meta=metadata)
@@ -93,6 +113,17 @@ class SkyportalCompleter(Completer):
 
 class InteractiveShell:
     """Resilient command center that remains active after request failures."""
+
+    _THINKING_STATUS = (
+        "[bold cyan]Skyportal is thinking…[/bold cyan]  "
+        "[dim](press Ctrl-C to stop)[/dim]"
+    )
+    _CONTINUING_STATUS = (
+        "[bold cyan]Skyportal is continuing…[/bold cyan]  "
+        "[dim](press Ctrl-C to stop)[/dim]"
+    )
+    _ANSI_ESCAPE_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
 
     PROMPT_STYLE = Style.from_dict(
         {
@@ -129,6 +160,7 @@ class InteractiveShell:
             "/logout": self._cmd_logout,
             "/github-token": self._cmd_github_token,
             "/status": self._cmd_status,
+            "/permission": self._cmd_permission,
             "/new": self._cmd_new,
             "/resume": self._cmd_resume,
             "/servers": self._cmd_servers,
@@ -256,6 +288,62 @@ class InteractiveShell:
     def _print_section(self, title: str, style: str = "#6b7280") -> None:
         """Print a lightweight terminal section divider."""
         self.console.print(Rule(title, characters="─", style=style, align="center"))
+
+    @classmethod
+    def _clean_terminal_text(cls, value: Any) -> str:
+        """Remove terminal control sequences from server-supplied display text."""
+        text = str(value) if value is not None else ""
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        text = cls._ANSI_ESCAPE_RE.sub("", text)
+        return cls._CONTROL_CHAR_RE.sub("", text)
+
+    @classmethod
+    def _bounded_one_line(cls, value: Any, limit: int) -> str:
+        text = " ".join(cls._clean_terminal_text(value).splitlines()).strip()
+        if len(text) <= limit:
+            return text
+        return text[: max(0, limit - 1)] + "…"
+
+    @classmethod
+    def _bounded_multiline(cls, value: Any, max_lines: int = 24, max_chars: int = 4096) -> str:
+        """Keep command results useful while bounding terminal transcript size."""
+        cleaned = cls._clean_terminal_text(value).strip()
+        if not cleaned:
+            return ""
+        lines = cleaned.splitlines()
+        truncated = len(lines) > max_lines
+        visible = lines[:max_lines]
+        rendered = "\n".join(visible)
+        if len(rendered) > max_chars:
+            truncated = True
+            rendered = rendered[:max_chars]
+        if truncated:
+            marker = "… output truncated"
+            rendered = rendered.rstrip()
+            if len(rendered) + len(marker) + 1 > max_chars:
+                rendered = rendered[: max(0, max_chars - len(marker) - 1)].rstrip()
+            rendered = (rendered + "\n" + marker).lstrip("\n")
+        return rendered
+
+    @staticmethod
+    def _sequence(message: Dict[str, Any]) -> Optional[int]:
+        try:
+            return int(message.get("sequence"))
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _message_key(cls, message: Dict[str, Any]) -> Tuple[str, Any]:
+        sequence = cls._sequence(message)
+        if sequence is not None:
+            return ("sequence", sequence)
+        # Persisted messages should always have a sequence, but exact-payload
+        # identity keeps a malformed/replayed row from scrolling forever.
+        try:
+            payload = json.dumps(message, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            payload = repr(message)
+        return ("payload", payload)
 
     def _show_onboarding(self) -> None:
         status = (
@@ -412,7 +500,94 @@ class InteractiveShell:
                 "[yellow]Usage:[/yellow] /github-token <set [owner/repo] | status | remove>"
             )
 
+    @staticmethod
+    def _permission_mode_value(value: Any) -> str:
+        mode = value.get("permission_mode") if isinstance(value, dict) else value
+        if mode not in _PERMISSION_MODES:
+            raise PortalError("Skyportal returned an invalid permission mode")
+        return str(mode)
+
+    @staticmethod
+    def _approval_id_value(value: Any) -> str:
+        return "" if value is None else str(value).strip()
+
+    def _fetch_permission_mode(self) -> str:
+        getter = getattr(self.client, "get_permission_mode", None)
+        if getter is None:
+            raise PortalError("This Skyportal deployment does not expose permission settings")
+        return self._permission_mode_value(getter())
+
+    def _permission_mode_for_approval(self) -> str:
+        """Read the shared mode, failing closed to an interactive prompt."""
+        try:
+            return self._fetch_permission_mode()
+        except PortalError as error:
+            self.console.print(
+                "[yellow]Could not verify autoapprove ({}); asking for safety.[/yellow]".format(
+                    self._bounded_one_line(error, 160)
+                )
+            )
+            return "ask"
+
+    def _cmd_permission(self, args: List[str]) -> None:
+        if len(args) > 1 or (args and args[0].lower() not in _PERMISSION_MODES):
+            self.console.print(
+                "[yellow]Usage:[/yellow] /permission [autoapprove|ask]"
+            )
+            return
+        self._require_api_connection()
+        requested = args[0].lower() if args else None
+        with self.console.status("[cyan]Checking approval policy…[/cyan]", spinner="dots"):
+            if requested is None:
+                mode = self._fetch_permission_mode()
+            else:
+                setter = getattr(self.client, "set_permission_mode", None)
+                if setter is None:
+                    raise PortalError(
+                        "This Skyportal deployment does not expose permission settings"
+                    )
+                mode = self._permission_mode_value(setter(requested))
+
+        if mode == "autoapprove":
+            self.console.print(
+                "[yellow]Permission mode: autoapprove.[/yellow] Supported pending actions "
+                "will be submitted automatically; server safety policies still apply."
+            )
+        else:
+            self.console.print(
+                "[green]Permission mode: ask.[/green] Gated actions will prompt for a decision."
+            )
+
     def _cmd_status(self, args: List[str]) -> None:
+        connected = self.client.is_authenticated()
+        remote: Optional[Dict[str, Any]] = None
+        remote_error: Optional[str] = None
+        permission_mode: Optional[str] = None
+        permission_error: Optional[str] = None
+        if connected:
+            try:
+                permission_mode = self._fetch_permission_mode()
+            except PortalError as error:
+                permission_error = str(error)
+        if connected and self.chat_id is not None:
+            try:
+                detailed_status = getattr(self.client, "get_execution_status", None)
+                if detailed_status is None:
+                    remote = self.client.chat_status(self.chat_id)
+                else:
+                    remote = detailed_status(self.chat_id)
+            except PortalError as error:
+                # Older deployments may not expose /execution-status/. The
+                # lightweight status endpoint still gives useful workflow and
+                # approval state, so degrade to it for that compatibility case.
+                if error.status_code in (404, 405):
+                    try:
+                        remote = self.client.chat_status(self.chat_id)
+                    except PortalError as fallback_error:
+                        remote_error = str(fallback_error)
+                else:
+                    remote_error = str(error)
+
         rows = Table.grid(padding=(0, 2))
         rows.add_column(style="dim")
         rows.add_column()
@@ -420,10 +595,20 @@ class InteractiveShell:
         rows.add_row(
             "API",
             "[green]connected[/green]"
-            if self.client.is_authenticated()
+            if connected
             else "[yellow]not connected[/yellow]",
         )
         rows.add_row("Agent", "Skyportal Agent")
+        if permission_mode is not None:
+            permission_style = "yellow" if permission_mode == "autoapprove" else "green"
+            rows.add_row("Permission", Text(permission_mode, style=permission_style))
+        elif permission_error:
+            rows.add_row(
+                "Permission",
+                Text("ask (unverified; prompting for safety)", style="yellow"),
+            )
+        else:
+            rows.add_row("Permission", "[dim]unknown (not connected)[/dim]")
         rows.add_row(
             "Chat",
             "#{}".format(self.chat_id) if self.chat_id is not None else "[dim]new chat[/dim]",
@@ -436,6 +621,47 @@ class InteractiveShell:
         )
         if len(self.selected_server_ids) > 1:
             rows.add_row("Default", str(self.selected_server_id))
+        if isinstance(remote, dict):
+            workflow_status = self._clean_terminal_text(remote.get("status", "unknown"))
+            status_style = {
+                "processing": "cyan",
+                "awaiting_approval": "yellow",
+                "error": "red",
+                "cancelled": "yellow",
+            }.get(workflow_status, "green")
+            rows.add_row("Workflow", Text(workflow_status or "unknown", style=status_style))
+
+            pending = remote.get("pending_approvals", [])
+            pending = pending if isinstance(pending, list) else []
+            rows.add_row("Approvals", Text(str(len(pending))))
+            if pending and isinstance(pending[0], dict):
+                detail = (
+                    pending[0].get("command")
+                    or pending[0].get("reason")
+                    or pending[0].get("type")
+                    or pending[0].get("approval_id")
+                    or "pending decision"
+                )
+                rows.add_row("Next approval", Text(self._bounded_one_line(detail, 160)))
+
+            live_command = remote.get("live_command_output")
+            if isinstance(live_command, dict) and live_command.get("command"):
+                # Deliberately do not render raw live output here. Older server
+                # versions expose an unredacted Redis preview; persisted tool
+                # messages are the safe/authoritative output surface.
+                rows.add_row(
+                    "Running",
+                    Text("$ " + self._bounded_one_line(live_command.get("command"), 160)),
+                )
+
+            live_plan = remote.get("live_plan")
+            if isinstance(live_plan, dict):
+                current = live_plan.get("current_step_index")
+                total = live_plan.get("total_steps")
+                if isinstance(current, int) and isinstance(total, int) and total > 0:
+                    rows.add_row("Plan", Text("step {}/{}".format(current + 1, total)))
+        elif remote_error:
+            rows.add_row("Remote", Text("unavailable: " + self._bounded_one_line(remote_error, 160), style="yellow"))
         rows.add_row("Credentials", str(CredentialStore.get_path()))
         self._print_section("Session status", style="#3b82f6")
         self.console.print(rows)
@@ -625,16 +851,21 @@ class InteractiveShell:
                 server_id=self.selected_server_id,
             )
         self.chat_id = chat_id
+        render_state = self._new_render_state()
         try:
-            with self.console.status(
-                "[bold cyan]Skyportal is thinking…[/bold cyan]  [dim](press Ctrl-C to stop)[/dim]",
-                spinner="dots12",
-            ):
-                turn = self.client.wait_for_chat(chat_id, after_sequence=self.last_sequence)
+            with self.console.status(self._THINKING_STATUS, spinner="dots12"):
+                turn = self.client.wait_for_chat(
+                    chat_id,
+                    after_sequence=self.last_sequence,
+                    timeout=None,
+                    on_progress=lambda messages: self._render_incremental_messages(
+                        messages, render_state
+                    ),
+                )
         except KeyboardInterrupt:
             self._cancel_active_turn(chat_id)
             return
-        self._process_turn(turn)
+        self._process_turn(turn, render_state=render_state)
 
     def _cancel_active_turn(self, chat_id: int) -> None:
         """Stop the running agent turn after a Ctrl-C, then keep the prompt."""
@@ -649,19 +880,138 @@ class InteractiveShell:
             "[yellow]■ Stopped.[/yellow] Chat #{} is still open; type to continue.".format(chat_id)
         )
 
-    def _process_turn(self, turn: ChatTurnResult) -> None:
+    @staticmethod
+    def _new_render_state() -> Dict[str, Any]:
+        return {"seen": set(), "rendered": False}
+
+    def _render_incremental_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        render_state: Dict[str, Any],
+    ) -> bool:
+        """Render one persisted-message batch once and advance the local cursor."""
+        seen = render_state.setdefault("seen", set())
+        fresh: List[Dict[str, Any]] = []
+        fresh_keys: List[Tuple[str, Any]] = []
+        sequences: List[int] = []
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            key = self._message_key(message)
+            if key in seen:
+                continue
+            fresh.append(message)
+            fresh_keys.append(key)
+            sequence = self._sequence(message)
+            if sequence is not None:
+                sequences.append(sequence)
+
+        rendered = self._render_assistant_messages(
+            fresh,
+            show_section=not bool(render_state.get("rendered")),
+        )
+        if rendered:
+            render_state["rendered"] = True
+        # Commit dedupe/cursor state only after the renderer accepted the
+        # whole batch. If a callback render raises, PortalClient retains every
+        # message in ChatTurnResult so the final pass can safely retry it.
+        seen.update(fresh_keys)
+        if sequences:
+            self.last_sequence = max(self.last_sequence, max(sequences))
+        return rendered
+
+    def _approval_was_accepted(
+        self,
+        chat_id: int,
+        approval_id: str,
+    ) -> bool:
+        """Reconcile an ambiguous approval POST timeout against server state."""
+        state = self.client.chat_status(chat_id)
+        if not isinstance(state, dict):
+            return False
+        if state.get("status") != "awaiting_approval":
+            return True
+        pending = state.get("pending_approvals", [])
+        if not isinstance(pending, list) or not pending:
+            return False
+        pending_ids = {
+            str(item.get("approval_id"))
+            for item in pending
+            if isinstance(item, dict) and item.get("approval_id") is not None
+        }
+        return approval_id not in pending_ids
+
+    def _submit_approval_with_recovery(
+        self,
+        chat_id: int,
+        approval: Dict[str, Any],
+        decision: str,
+        *,
+        autoapproved: bool = False,
+    ) -> bool:
+        """Submit a decision; recover when an older synchronous server times out.
+
+        Older deployments execute the resumed workflow inside the approval POST.
+        The client can therefore hit its request timeout after the decision was
+        durably accepted. A single status reconciliation avoids resubmitting (and
+        potentially re-running) that approval. Explicit HTTP failures still fail.
+        Returns True when timeout recovery was needed.
+        """
+        try:
+            if autoapproved:
+                self.client.submit_chat_approval(
+                    chat_id,
+                    approval,
+                    decision,
+                    autoapproved=True,
+                )
+            else:
+                self.client.submit_chat_approval(chat_id, approval, decision)
+            return False
+        except PortalError as error:
+            if (
+                autoapproved
+                and error.status_code == 409
+                and error.code == "autoapproval_policy_conflict"
+            ):
+                raise _AutoapprovalPolicyConflict from error
+            if error.status_code is not None:
+                raise
+            original_error: BaseException = error
+        except TimeoutError as error:
+            original_error = error
+
+        try:
+            accepted = self._approval_was_accepted(
+                chat_id, str(approval.get("approval_id", ""))
+            )
+        except (PortalError, TimeoutError) as reconciliation_error:
+            raise original_error from reconciliation_error
+        if not accepted:
+            raise original_error
+        return True
+
+    def _process_turn(
+        self,
+        turn: ChatTurnResult,
+        render_state: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Render a completed turn and resolve requested approvals."""
+        if render_state is None:
+            render_state = self._new_render_state()
+        handled_approvals: set[str] = set()
+        approval_settlement_deadline: Optional[float] = None
         while True:
             self.chat_id = turn.chat_id
             self._remember_chat(turn.chat_id)
+            self._render_incremental_messages(turn.messages, render_state)
             self.last_sequence = max(self.last_sequence, turn.latest_sequence)
-            rendered = self._render_assistant_messages(turn.messages)
             if turn.status == "error":
                 raise PortalError(
                     "The Skyportal agent reported an error for chat #{}".format(turn.chat_id)
                 )
             if turn.status != "awaiting_approval":
-                if not rendered:
+                if not render_state.get("rendered"):
                     # _render_assistant_messages() now surfaces thoughts,
                     # tool-call announcements, and generic tool results (not
                     # just a final text answer), so reaching here means the
@@ -684,7 +1034,59 @@ class InteractiveShell:
                     "Chat #{} is awaiting approval without approval details".format(turn.chat_id)
                 )
 
-            approval = turn.pending_approvals[0]
+            visible_approval_ids = {
+                self._approval_id_value(item.get("approval_id"))
+                for item in turn.pending_approvals
+                if isinstance(item, dict)
+                and self._approval_id_value(item.get("approval_id"))
+            }
+            if visible_approval_ids & handled_approvals:
+                # The approval POST can finish before the status snapshot that
+                # still advertises it is replaced. Do not submit a second id
+                # from that stale snapshot (or resubmit the first). Poll at a
+                # bounded cadence until the handled id disappears or the
+                # workflow advances.
+                if (
+                    approval_settlement_deadline is None
+                    or time.monotonic() >= approval_settlement_deadline
+                ):
+                    raise PortalError(
+                        "Skyportal did not clear an approval that was already submitted. "
+                        "Use /status before retrying; it will not be submitted twice."
+                    )
+                try:
+                    time.sleep(_APPROVAL_SETTLEMENT_POLL_INTERVAL)
+                    turn = self.client.wait_for_chat(
+                        turn.chat_id,
+                        after_sequence=self.last_sequence,
+                        timeout=None,
+                        on_progress=lambda messages: self._render_incremental_messages(
+                            messages, render_state
+                        ),
+                    )
+                except KeyboardInterrupt:
+                    self._cancel_active_turn(turn.chat_id)
+                    return
+                continue
+
+            remaining = [
+                item
+                for item in turn.pending_approvals
+                if self._approval_id_value(item.get("approval_id"))
+                not in handled_approvals
+            ]
+            if not remaining:
+                raise PortalError(
+                    "Chat #{} is awaiting approval without a usable approval ID".format(
+                        turn.chat_id
+                    )
+                )
+            approval = remaining[0]
+            approval_id = self._approval_id_value(approval.get("approval_id"))
+            if not approval_id:
+                raise PortalError(
+                    "Chat #{} returned an approval without an approval ID".format(turn.chat_id)
+                )
             description = (
                 approval.get("executed_command")
                 or approval.get("command")
@@ -692,29 +1094,85 @@ class InteractiveShell:
                 or json.dumps(approval, indent=2, sort_keys=True)
             )
             self._print_section("Approval requested", style="yellow")
-            self.console.print(str(description))
-            try:
-                answer = self.session.prompt("Approve this action? [y/N]: ").strip().lower()
-            except (KeyboardInterrupt, EOFError):
-                answer = ""
-            decision = "approved" if answer in ("y", "yes") else "rejected"
-            try:
-                with self.console.status(
-                    "[cyan]Submitting {}…[/cyan] [dim](Ctrl-C to stop)[/dim]".format(decision),
-                    spinner="dots",
-                ):
-                    self.client.submit_chat_approval(turn.chat_id, approval, decision)
-                    turn = self.client.wait_for_chat(
-                        turn.chat_id,
-                        after_sequence=self.last_sequence,
+            self.console.print(Text(self._clean_terminal_text(description)))
+            approval_type = str(approval.get("type", "") or "")
+            autoapprove = (
+                approval_type in _AUTOAPPROVE_TYPES
+                and self._permission_mode_for_approval() == "autoapprove"
+            )
+            if autoapprove:
+                decision = "approved"
+                self.console.print(
+                    "[yellow]Auto-approving under the shared account policy.[/yellow]"
+                )
+            else:
+                if approval_type not in _AUTOAPPROVE_TYPES:
+                    self.console.print(
+                        "[dim]This approval type requires an explicit decision.[/dim]"
                     )
+                try:
+                    answer = self.session.prompt("Approve this action? [y/N]: ").strip().lower()
+                except (KeyboardInterrupt, EOFError):
+                    answer = ""
+                decision = "approved" if answer in ("y", "yes") else "rejected"
+            try:
+                while True:
+                    try:
+                        with self.console.status(
+                            "[cyan]Submitting {}…[/cyan] "
+                            "[dim](Ctrl-C to stop)[/dim]".format(decision),
+                            spinner="dots",
+                        ) as status:
+                            recovered = self._submit_approval_with_recovery(
+                                turn.chat_id,
+                                approval,
+                                decision,
+                                autoapproved=autoapprove,
+                            )
+                            handled_approvals.add(approval_id)
+                            approval_settlement_deadline = (
+                                time.monotonic() + _APPROVAL_SETTLEMENT_TIMEOUT
+                            )
+                            status.update(self._CONTINUING_STATUS)
+                            if recovered:
+                                self.console.print(
+                                    "[dim]Approval was accepted; reattached after the older "
+                                    "server's response timed out.[/dim]"
+                                )
+                            turn = self.client.wait_for_chat(
+                                turn.chat_id,
+                                after_sequence=self.last_sequence,
+                                timeout=None,
+                                on_progress=lambda messages: self._render_incremental_messages(
+                                    messages, render_state
+                                ),
+                            )
+                        break
+                    except _AutoapprovalPolicyConflict:
+                        autoapprove = False
+                        self.console.print(
+                            "[yellow]Autoapprove was disabled before this action was "
+                            "submitted; an explicit decision is required.[/yellow]"
+                        )
+                        try:
+                            answer = self.session.prompt(
+                                "Approve this action? [y/N]: "
+                            ).strip().lower()
+                        except (KeyboardInterrupt, EOFError):
+                            answer = ""
+                        decision = "approved" if answer in ("y", "yes") else "rejected"
             except KeyboardInterrupt:
                 self._cancel_active_turn(turn.chat_id)
                 return
 
-    def _render_assistant_messages(self, messages: List[Dict[str, Any]]) -> bool:
+    def _render_assistant_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        show_section: bool = True,
+    ) -> bool:
         rendered = False
-        for message in sorted(messages, key=lambda item: int(item.get("sequence", 0))):
+        for message in sorted(messages, key=lambda item: self._sequence(item) or 0):
             role = message.get("role")
             if role == "assistant":
                 line = self._assistant_message_line(message)
@@ -722,7 +1180,8 @@ class InteractiveShell:
                     continue
                 if not rendered:
                     self.console.print()
-                    self._print_section("[#3b82f6]Skyportal agent[/#3b82f6]")
+                    if show_section:
+                        self._print_section("[#3b82f6]Skyportal agent[/#3b82f6]")
                 self.console.print(line)
                 rendered = True
             elif role == "tool":
@@ -731,7 +1190,8 @@ class InteractiveShell:
                     continue
                 if not rendered:
                     self.console.print()
-                    self._print_section("[#3b82f6]Skyportal agent[/#3b82f6]")
+                    if show_section:
+                        self._print_section("[#3b82f6]Skyportal agent[/#3b82f6]")
                 self.console.print(line)
                 rendered = True
         if rendered:
@@ -753,10 +1213,14 @@ class InteractiveShell:
         metadata = message.get("metadata", {})
         msg_type = metadata.get("type") if isinstance(metadata, dict) else None
         if msg_type == "react_thought":
-            return Text.from_markup("[dim italic]· {}[/dim italic]".format(text))
+            line = Text("· ", style="dim italic")
+            line.append(self._clean_terminal_text(text), style="dim italic")
+            return line
         if msg_type == "react_action":
-            return Text.from_markup("[dim]→ calling[/dim] [bold]{}[/bold]".format(text))
-        return Markdown(text)
+            line = Text("→ calling ", style="dim")
+            line.append(self._clean_terminal_text(text), style="bold")
+            return line
+        return Markdown(self._clean_terminal_text(text))
 
     @staticmethod
     def _tool_result_line(message: Dict[str, Any]) -> Optional[Text]:
@@ -776,27 +1240,43 @@ class InteractiveShell:
             return None
         command = metadata.get("terminal_command")
         if command:
-            hostname = metadata.get("terminal_server_hostname") or "unknown host"
+            hostname = InteractiveShell._bounded_one_line(
+                metadata.get("terminal_server_hostname") or "unknown host", 120
+            )
+            command_text = InteractiveShell._bounded_one_line(command, 400)
             success = metadata.get("terminal_success")
-            marker = "[dim]?[/dim]" if success is None else ("[green]✓[/green]" if success else "[red]✗[/red]")
-            output = (metadata.get("terminal_output") or "").strip()
-            output = output.splitlines()[0] if output else ""
-            if len(output) > 120:
-                output = output[:117] + "..."
-            line = "[dim]\\[{}][/dim] {} [bold]$[/bold] {}".format(hostname, marker, command)
+            marker = "?" if success is None else ("✓" if success else "✗")
+            marker_style = "dim" if success is None else ("green" if success else "red")
+            output = InteractiveShell._bounded_multiline(
+                metadata.get("terminal_output") or ""
+            )
+            line = Text()
+            line.append("[{}]".format(hostname), style="dim")
+            line.append(" ")
+            line.append(marker, style=marker_style)
+            line.append(" $ ", style="bold")
+            line.append(command_text)
             if output:
-                line += "  [dim]-> {}[/dim]".format(output)
-            return Text.from_markup(line)
+                for output_line in output.splitlines():
+                    line.append("\n  ")
+                    line.append(output_line, style="dim")
+            return line
 
         tool_name = metadata.get("tool_name")
         if not tool_name:
             return None
         success = metadata.get("success")
-        marker = "[dim]?[/dim]" if success is None else ("[green]✓[/green]" if success else "[red]✗[/red]")
-        return Text.from_markup("[dim]tool[/dim] {} [bold]{}[/bold]".format(marker, tool_name))
+        marker = "?" if success is None else ("✓" if success else "✗")
+        marker_style = "dim" if success is None else ("green" if success else "red")
+        line = Text("tool", style="dim")
+        line.append(" ")
+        line.append(marker, style=marker_style)
+        line.append(" ")
+        line.append(InteractiveShell._bounded_one_line(tool_name, 160), style="bold")
+        return line
 
     def _render_history(self, messages: List[Dict[str, Any]]) -> None:
-        ordered = sorted(messages, key=lambda item: int(item.get("sequence", 0)))
+        ordered = sorted(messages, key=lambda item: self._sequence(item) or 0)
         printable = []
         for m in ordered:
             role = m.get("role")
@@ -819,15 +1299,19 @@ class InteractiveShell:
             if role == "user":
                 line = Text()
                 line.append("you  ", style="bold #f0b429")
-                line.append(text)
+                line.append(self._clean_terminal_text(text))
                 self.console.print(line)
             elif msg_type == "react_thought":
-                self.console.print(Text.from_markup("[dim italic]· {}[/dim italic]".format(text)))
+                line = Text("· ", style="dim italic")
+                line.append(self._clean_terminal_text(text), style="dim italic")
+                self.console.print(line)
             elif msg_type == "react_action":
-                self.console.print(Text.from_markup("[dim]→ calling[/dim] [bold]{}[/bold]".format(text)))
+                line = Text("→ calling ", style="dim")
+                line.append(self._clean_terminal_text(text), style="bold")
+                self.console.print(line)
             else:
                 self.console.print("[bold #3b82f6]agent[/bold #3b82f6]")
-                self.console.print(Markdown(text))
+                self.console.print(Markdown(self._clean_terminal_text(text)))
         self.console.print()
 
     @staticmethod

--- a/skyportalai/__init__.py
+++ b/skyportalai/__init__.py
@@ -17,6 +17,7 @@ from .types import (
     Message,
     MessagesPage,
     PendingApproval,
+    PermissionMode,
     User,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "ChatStatus",
     "KubernetesCluster",
     "PendingApproval",
+    "PermissionMode",
     "ApprovalResult",
     "Message",
     "MessagesPage",

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -19,12 +19,13 @@ from ._version import __version__
 from .resources.chat import ChatResource
 from .resources.kubernetes import KubernetesResource
 from .resources.me import fetch_me
-from .types import User
+from .types import PermissionMode, User
 
 DEFAULT_BASE_URL = "https://app.skyportal.ai"
 
 #: Hosts allowed to use plain ``http://`` (local development only).
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_PERMISSION_MODES = frozenset({"ask", "autoapprove"})
 
 
 def _redacted(base_url: str) -> str:
@@ -230,6 +231,38 @@ class Skyportal:
     def me(self) -> User:
         """Return the authenticated user (the owner of the API key)."""
         return fetch_me(self)
+
+    def get_permission_mode(self) -> PermissionMode:
+        """Return the account's shared agent-approval mode.
+
+        ``ask`` leaves each gated action for an explicit decision;
+        ``autoapprove`` lets supported clients submit those concrete approvals
+        automatically. Server-side safety and environment policies still
+        apply in either mode.
+        """
+        data = self._request("GET", "/api/v1/agent/permission/")
+        return self._parse_permission_mode(data)
+
+    def set_permission_mode(self, mode: PermissionMode) -> PermissionMode:
+        """Persist the shared agent-approval mode for this account."""
+        if mode not in _PERMISSION_MODES:
+            raise ValueError("permission mode must be 'ask' or 'autoapprove'")
+        data = self._request(
+            "PUT",
+            "/api/v1/agent/permission/",
+            json={"permission_mode": mode},
+        )
+        return self._parse_permission_mode(data)
+
+    @staticmethod
+    def _parse_permission_mode(data: object) -> PermissionMode:
+        mode = data.get("permission_mode") if isinstance(data, dict) else None
+        if mode not in _PERMISSION_MODES:
+            raise APIError(
+                "API returned an invalid permission mode.",
+                body=data,
+            )
+        return mode
 
     def close(self) -> None:
         """Close the internally-created HTTP session.

--- a/skyportalai/chat.py
+++ b/skyportalai/chat.py
@@ -70,7 +70,7 @@ class Chat:
     def cancel(self, reason: str | None = None) -> dict:
         return self._client.chat.cancel(self.chat_id, reason=reason)
 
-    def wait(self, poll_interval: float = 1.0, timeout: float = 300.0,
+    def wait(self, poll_interval: float = 1.0, timeout: float | None = None,
              on_approval: ApprovalCallback | None = None) -> ChatStatus:
         return self._client.chat.wait(
             self.chat_id, poll_interval=poll_interval, timeout=timeout,

--- a/skyportalai/cli/chat.py
+++ b/skyportalai/cli/chat.py
@@ -59,9 +59,13 @@ def send(
     ] = None,
     wait: Annotated[bool, typer.Option("--wait", help="Wait for the turn to settle.")] = False,
     timeout: Annotated[
-        float,
-        typer.Option("--timeout", min=0.001, help="Maximum wait in seconds."),
-    ] = 300.0,
+        float | None,
+        typer.Option(
+            "--timeout",
+            min=0.001,
+            help="Optional maximum wait in seconds; waits indefinitely when omitted.",
+        ),
+    ] = None,
     poll_interval: Annotated[
         float,
         typer.Option("--poll-interval", min=0.0, help="Seconds between status polls."),
@@ -376,7 +380,14 @@ def select_servers(
 def wait_for_chat(
     context: typer.Context,
     chat_id: Annotated[int, typer.Argument(min=1)],
-    timeout: Annotated[float, typer.Option("--timeout", min=0.001)] = 300.0,
+    timeout: Annotated[
+        float | None,
+        typer.Option(
+            "--timeout",
+            min=0.001,
+            help="Optional maximum wait in seconds; waits indefinitely when omitted.",
+        ),
+    ] = None,
     poll_interval: Annotated[float, typer.Option("--poll-interval", min=0.0)] = 1.0,
 ) -> None:
     """Wait until a chat settles or needs approval."""

--- a/skyportalai/resources/chat.py
+++ b/skyportalai/resources/chat.py
@@ -12,7 +12,7 @@ import time
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
-from .._exceptions import WaitTimeoutError
+from .._exceptions import APIConnectionError, APIError, SkyportalError, WaitTimeoutError
 from ..chat import ApprovalCallback, Chat
 from ..types import ApprovalResult, ChatStatus, MessagesPage
 
@@ -104,13 +104,16 @@ class ChatResource:
     def submit_approval(self, chat_id: int, approval_id: str, *, decision: str,
                         approval_type: str = "bash_command",
                         command: str | None = None,
-                        reason: str | None = None) -> ApprovalResult:
+                        reason: str | None = None,
+                        autoapproved: bool = False) -> ApprovalResult:
         """Submit an approval decision (``approved`` or ``rejected``)."""
         body: dict = {"decision": decision, "type": approval_type}
         if command is not None:
             body["command"] = command
         if reason is not None:
             body["rejection_reason"] = reason
+        if autoapproved:
+            body["autoapproved"] = True
         data = self._client._request(
             "POST", self._approval_path(chat_id, approval_id), json=body,
         )
@@ -177,43 +180,147 @@ class ChatResource:
         )
 
     def wait(self, chat_id: int, *, poll_interval: float = 1.0,
-             timeout: float = 300.0,
+             timeout: float | None = None,
              on_approval: ApprovalCallback | None = None) -> ChatStatus:
         """Poll until the workflow settles, or raise ``WaitTimeoutError``.
 
         ``processing`` and ``uninitialized`` keep polling. On
         ``awaiting_approval``: with no callback the status is returned for the
-        caller to decide; with ``on_approval``, each pending approval is passed
-        to the callback — True approves, False rejects, None leaves it — and
-        polling continues if any decision was submitted.
+        caller to decide unless the account's shared permission mode is
+        ``autoapprove``. Autoapproval still submits each concrete approval to
+        the normal endpoint, one at a time, so server audit/checkpoint behavior
+        is preserved. An explicit ``on_approval`` callback takes precedence:
+        True approves, False rejects, and None leaves an approval pending.
+
+        If the permission setting cannot be read, this fails closed by
+        returning the awaiting-approval status. Approval ids already submitted
+        during this wait are never submitted twice, even if a status response
+        is stale.
         """
-        deadline = time.monotonic() + timeout
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        handled_approval_ids: set[str] = set()
         while True:
             current = self.get_status(chat_id)
             if current.status == "awaiting_approval":
+                visible_approval_ids = {
+                    approval.approval_id
+                    for approval in current.pending_approvals
+                    if approval.approval_id
+                }
+                # A status snapshot that still contains a submitted id is
+                # stale. Do not act on a second id from that same snapshot:
+                # the resumed workflow may not have reacquired its lease yet.
+                # Poll until every handled id disappears, then evaluate the
+                # next concrete approval.
+                if visible_approval_ids & handled_approval_ids:
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise WaitTimeoutError(
+                            f"Chat {chat_id} was still busy after {timeout:.0f}s."
+                        )
+                    time.sleep(poll_interval)
+                    continue
+                if not current.pending_approvals:
+                    return current
+
+                # Approval order is checkpoint order. A malformed first entry
+                # cannot be skipped in favor of a later valid id without
+                # risking an out-of-order resume.
+                approval = current.pending_approvals[0]
+                if not approval.approval_id:
+                    return current
+                # Older deployments omit the type for bash approvals.
+                # Unknown non-empty types must never be silently coerced into
+                # bash requests by the server's compatibility path. Callers
+                # can still opt in explicitly through submit_approval().
+                if approval.type not in ("", "bash_command", "plan"):
+                    return current
+                decision = None
+                persisted_autoapproval = False
                 if on_approval is None:
-                    return current
-                acted = False
-                for approval in current.pending_approvals:
+                    try:
+                        autoapprove = self._client.get_permission_mode() == "autoapprove"
+                    except SkyportalError:
+                        autoapprove = False
+                    if not autoapprove:
+                        return current
+                    decision = True
+                    persisted_autoapproval = True
+                else:
                     decision = on_approval(approval)
-                    if decision is None:
-                        continue
-                    self.submit_approval(
-                        chat_id, approval.approval_id,
-                        decision="approved" if decision else "rejected",
-                        approval_type=approval.type or "bash_command",
-                        command=approval.command or None,
-                    )
-                    acted = True
-                if not acted:
+                if approval is None or decision is None:
                     return current
+
+                submitted = self._submit_wait_approval(
+                    chat_id,
+                    approval.approval_id,
+                    decision="approved" if decision else "rejected",
+                    approval_type=approval.type or "bash_command",
+                    command=approval.command or None,
+                    autoapproved=persisted_autoapproval,
+                )
+                if not submitted:
+                    # The shared policy changed after it was read. The server
+                    # guarantees the marked decision had no side effects, so
+                    # return the still-pending status for an explicit choice.
+                    return current
+                handled_approval_ids.add(approval.approval_id)
+                if timeout is not None:
+                    deadline = time.monotonic() + timeout
             elif current.status not in BUSY_STATUSES:
                 return current
-            if time.monotonic() >= deadline:
+            if deadline is not None and time.monotonic() >= deadline:
                 raise WaitTimeoutError(
                     f"Chat {chat_id} was still busy after {timeout:.0f}s."
                 )
             time.sleep(poll_interval)
+
+    def _submit_wait_approval(
+        self,
+        chat_id: int,
+        approval_id: str,
+        *,
+        decision: str,
+        approval_type: str,
+        command: str | None,
+        autoapproved: bool,
+    ) -> bool:
+        """Submit once and reconcile an ambiguous transport timeout."""
+        try:
+            self.submit_approval(
+                chat_id,
+                approval_id,
+                decision=decision,
+                approval_type=approval_type,
+                command=command,
+                autoapproved=autoapproved,
+            )
+            return True
+        except APIError as error:
+            code = error.body.get("code") if isinstance(error.body, dict) else None
+            if (
+                autoapproved
+                and error.status_code == 409
+                and code == "autoapproval_policy_conflict"
+            ):
+                return False
+            raise
+        except APIConnectionError as error:
+            original_error = error
+
+        try:
+            current = self.get_status(chat_id)
+        except SkyportalError as reconciliation_error:
+            raise original_error from reconciliation_error
+        still_pending = (
+            current.status == "awaiting_approval"
+            and any(
+                approval.approval_id == approval_id
+                for approval in current.pending_approvals
+            )
+        )
+        if still_pending:
+            raise original_error
+        return True
 
     # -- read-only observability ----------------------------------------------
 

--- a/skyportalai/resources/chat.py
+++ b/skyportalai/resources/chat.py
@@ -247,7 +247,7 @@ class ChatResource:
                     persisted_autoapproval = True
                 else:
                     decision = on_approval(approval)
-                if approval is None or decision is None:
+                if decision is None:
                     return current
 
                 submitted = self._submit_wait_approval(

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
+
+PermissionMode = Literal["ask", "autoapprove"]
 
 
 @dataclass(frozen=True)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from skyportalai._client import Skyportal
@@ -72,6 +74,66 @@ def test_create_chat_posts_atomic_multi_server_scope(requests_mock):
         "active_host_id": 9,
         "selected_namespaces": {"12": ["default", "vllm"]},
     }
+
+
+def test_multihost_kubernetes_scope_is_preserved_through_autoapproval_resume(
+    requests_mock,
+):
+    requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/",
+        status_code=202,
+        json={"chat_id": 5, "status": "processing"},
+    )
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/chat/5/status/",
+        [
+            {"json": {"status": "awaiting_approval", "pending_approvals": [
+                {"approval_id": "k8s-1", "type": "bash_command", "command": "kubectl get pods"},
+            ]}},
+            {"json": {"status": "idle"}},
+        ],
+    )
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/permission/",
+        json={"permission_mode": "autoapprove"},
+    )
+    approval = requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/approve/k8s-1/",
+        json={"success": True, "decision": "approved"},
+    )
+
+    chat = _client().chat.create_chat(
+        "inspect both clusters",
+        server_ids=[9, 12],
+        active_server_id=9,
+        active_host_id=9,
+        selected_namespaces={9: ["default"], 12: ["vllm", "monitoring"]},
+    )
+    creation_body = requests_mock.request_history[0].json()
+    result = chat.wait(poll_interval=0.0)
+
+    assert result.status == "idle"
+    assert creation_body == {
+        "message": "inspect both clusters",
+        "selected_server_ids": [9, 12],
+        "active_server_id": 9,
+        "active_host_id": 9,
+        "selected_namespaces": {
+            "9": ["default"],
+            "12": ["vllm", "monitoring"],
+        },
+    }
+    assert approval.last_request.json() == {
+        "decision": "approved",
+        "type": "bash_command",
+        "command": "kubectl get pods",
+        "autoapproved": True,
+    }
+    assert not [
+        request
+        for request in requests_mock.request_history
+        if request.path.endswith("/select-servers/")
+    ]
 
 
 def test_create_chat_preserves_explicit_empty_multi_server_scope(requests_mock):
@@ -289,9 +351,138 @@ def test_wait_without_callback_returns_awaiting_approval(requests_mock):
     requests_mock.get(f"{BASE}/api/v1/agent/chat/5/status/",
                       json={"status": "awaiting_approval",
                             "pending_approvals": [{"approval_id": "a1"}]})
+    requests_mock.get(f"{BASE}/api/v1/agent/permission/",
+                      json={"permission_mode": "ask"})
     status = _client().chat.wait(5, timeout=30.0, poll_interval=0.0)
     assert status.status == "awaiting_approval"
+    assert requests_mock.call_count == 2
+
+
+def test_wait_autoapproves_consecutive_ids_one_authoritative_snapshot_at_a_time(
+    requests_mock,
+):
+    status_url = f"{BASE}/api/v1/agent/chat/5/status/"
+    requests_mock.get(
+        status_url,
+        [
+            {"json": {"status": "awaiting_approval", "pending_approvals": [
+                {"approval_id": "a1", "type": "bash_command", "command": "uptime"},
+                {"approval_id": "a2", "type": "plan"},
+            ]}},
+            # The first decision has not cleared from this snapshot, so a2
+            # must not be submitted behind the active resume lease.
+            {"json": {"status": "awaiting_approval", "pending_approvals": [
+                {"approval_id": "a1", "type": "bash_command", "command": "uptime"},
+                {"approval_id": "a2", "type": "plan"},
+            ]}},
+            {"json": {"status": "awaiting_approval", "pending_approvals": [
+                {"approval_id": "a2", "type": "plan"},
+            ]}},
+            {"json": {"status": "processing"}},
+            {"json": {"status": "idle"}},
+        ],
+    )
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/permission/",
+        json={"permission_mode": "autoapprove"},
+    )
+    first = requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/approve/a1/",
+        json={"success": True, "decision": "approved"},
+    )
+    second = requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/approve/a2/",
+        json={"success": True, "decision": "approved"},
+    )
+
+    result = _client().chat.wait(5, timeout=30.0, poll_interval=0.0)
+
+    assert result.status == "idle"
+    assert first.call_count == 1
+    assert second.call_count == 1
+    assert first.last_request.json()["autoapproved"] is True
+    assert second.last_request.json()["autoapproved"] is True
+    paths = [request.path for request in requests_mock.request_history]
+    first_index = paths.index("/api/v1/agent/chat/5/approve/a1/")
+    second_index = paths.index("/api/v1/agent/chat/5/approve/a2/")
+    assert "/api/v1/agent/chat/5/status/" in paths[first_index + 1:second_index]
+
+
+def test_wait_autoapproval_policy_conflict_returns_pending_without_retry(requests_mock):
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/chat/5/status/",
+        json={"status": "awaiting_approval", "pending_approvals": [
+            {"approval_id": "a1", "type": "bash_command", "command": "uptime"},
+        ]},
+    )
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/permission/",
+        json={"permission_mode": "autoapprove"},
+    )
+    submit = requests_mock.post(
+        f"{BASE}/api/v1/agent/chat/5/approve/a1/",
+        status_code=409,
+        json={
+            "error": "Autoapproval is no longer enabled",
+            "code": "autoapproval_policy_conflict",
+        },
+    )
+
+    result = _client().chat.wait(5, poll_interval=0.0)
+
+    assert result.status == "awaiting_approval"
+    assert submit.call_count == 1
+    assert submit.last_request.json()["autoapproved"] is True
+
+
+def test_wait_autoapprove_fails_closed_for_unknown_approval_type(requests_mock):
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/chat/5/status/",
+        json={"status": "awaiting_approval", "pending_approvals": [
+            {"approval_id": "future-1", "type": "future_privileged_action"},
+        ]},
+    )
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/permission/",
+        json={"permission_mode": "autoapprove"},
+    )
+
+    result = _client().chat.wait(5, timeout=30.0, poll_interval=0.0)
+
+    assert result.status == "awaiting_approval"
+    assert not [r for r in requests_mock.request_history if r.method == "POST"]
+
+
+def test_wait_does_not_skip_malformed_first_approval_to_autoapprove_later_id(
+    requests_mock,
+):
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/chat/5/status/",
+        json={"status": "awaiting_approval", "pending_approvals": [
+            {"approval_id": None, "type": "bash_command"},
+            {"approval_id": "a2", "type": "bash_command", "command": "uptime"},
+        ]},
+    )
+
+    result = _client().chat.wait(5, poll_interval=0.0)
+
+    assert result.status == "awaiting_approval"
     assert requests_mock.call_count == 1
+
+
+def test_wait_fails_closed_when_permission_endpoint_is_unavailable(requests_mock):
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/chat/5/status/",
+        json={"status": "awaiting_approval", "pending_approvals": [
+            {"approval_id": "a1", "type": "bash_command"},
+        ]},
+    )
+    requests_mock.get(f"{BASE}/api/v1/agent/permission/", status_code=404)
+
+    result = _client().chat.wait(5, timeout=30.0, poll_interval=0.0)
+
+    assert result.status == "awaiting_approval"
+    assert not [r for r in requests_mock.request_history if r.method == "POST"]
 
 
 def test_wait_on_approval_true_approves_and_keeps_polling(requests_mock):
@@ -347,6 +538,32 @@ def test_wait_times_out(requests_mock):
                       json={"status": "processing"})
     with pytest.raises(WaitTimeoutError):
         _client().chat.wait(5, timeout=0.0, poll_interval=0.0)
+
+
+def test_wait_default_is_indefinite(requests_mock):
+    requests_mock.get(
+        f"{BASE}/api/v1/agent/chat/5/status/",
+        [{"json": {"status": "processing"}}, {"json": {"status": "idle"}}],
+    )
+
+    with patch(
+        "skyportalai.resources.chat.time.monotonic",
+        side_effect=AssertionError("deadline used"),
+    ), patch("skyportalai.resources.chat.time.sleep"):
+        result = _client().chat.wait(5, poll_interval=0.0)
+
+    assert result.status == "idle"
+
+
+def test_bound_chat_wait_defaults_to_indefinite():
+    client = _client()
+    chat = Chat(client, 5)
+    settled = ChatStatus(status="idle")
+
+    with patch.object(client.chat, "wait", return_value=settled) as wait:
+        assert chat.wait() is settled
+
+    wait.assert_called_once_with(5, poll_interval=1.0, timeout=None, on_approval=None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -140,6 +140,34 @@ def test_send_wait_targets_server_and_returns_json(fake_client):
     assert payload["data"]["messages"][0]["content"] == "done"
 
 
+def test_send_wait_defaults_to_indefinite_for_long_running_turns(fake_client):
+    result = runner.invoke(
+        app,
+        ["--json", "chat", "send", "inspect every host", "--server", "7", "--wait"],
+    )
+
+    assert result.exit_code == 0
+    assert fake_client.chat.calls[0:2] == [
+        ("create_chat", "inspect every host", 7, None, None, None, None),
+        ("wait", 42, None, 1.0),
+    ]
+
+
+def test_chat_wait_defaults_indefinite_and_keeps_finite_timeout_opt_in(fake_client):
+    indefinite = runner.invoke(app, ["--json", "chat", "wait", "42"])
+    finite = runner.invoke(
+        app,
+        ["--json", "chat", "wait", "42", "--timeout", "12", "--poll-interval", "0"],
+    )
+
+    assert indefinite.exit_code == 0
+    assert finite.exit_code == 0
+    assert fake_client.chat.calls == [
+        ("wait", 42, None, 1.0),
+        ("wait", 42, 12.0, 0.0),
+    ]
+
+
 def test_send_without_wait_does_not_fetch_messages(fake_client):
     result = runner.invoke(app, ["--json", "chat", "send", "inspect", "--server", "7"])
 

--- a/tests/test_client_config.py
+++ b/tests/test_client_config.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 
 from skyportalai._client import DEFAULT_BASE_URL, Skyportal
-from skyportalai._exceptions import SkyportalError
+from skyportalai._exceptions import APIError, SkyportalError
 
 
 def test_api_key_from_argument():
@@ -187,3 +187,36 @@ def test_allow_insecure_other_values_still_raise(monkeypatch):
     monkeypatch.setenv("SKYPORTAL_ALLOW_INSECURE", "true")
     with pytest.raises(SkyportalError, match="non-HTTPS"):
         Skyportal(api_key="sk-x", base_url="http://internal.corp:8000")
+
+
+def test_permission_mode_get_and_put_use_shared_account_endpoint(requests_mock):
+    endpoint = "https://api.test/api/v1/agent/permission/"
+    requests_mock.get(endpoint, json={"permission_mode": "ask", "read_only_mode": False})
+    requests_mock.put(
+        endpoint,
+        json={"permission_mode": "autoapprove", "read_only_mode": False},
+    )
+    client = Skyportal(api_key="sk-test", base_url="https://api.test")
+
+    assert client.get_permission_mode() == "ask"
+    assert client.set_permission_mode("autoapprove") == "autoapprove"
+    assert requests_mock.last_request.json() == {"permission_mode": "autoapprove"}
+
+
+def test_permission_mode_rejects_invalid_input_before_request(requests_mock):
+    client = Skyportal(api_key="sk-test", base_url="https://api.test")
+
+    with pytest.raises(ValueError, match="ask.*autoapprove"):
+        client.set_permission_mode("everything")
+
+    assert not requests_mock.called
+
+
+def test_permission_mode_rejects_malformed_server_response(requests_mock):
+    requests_mock.get(
+        "https://api.test/api/v1/agent/permission/",
+        json={"permission_mode": "unexpected"},
+    )
+
+    with pytest.raises(APIError, match="invalid permission mode"):
+        Skyportal(api_key="sk-test", base_url="https://api.test").get_permission_mode()

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -3,7 +3,7 @@
 import json
 import os
 from io import BytesIO
-from unittest.mock import patch
+from unittest.mock import call, patch
 from urllib.error import HTTPError
 
 import pytest
@@ -277,29 +277,48 @@ def test_follow_up_message_uses_existing_chat(credential_path):
     assert json.loads(request.data) == {"message": "Now show memory"}
 
 
+def test_get_execution_status_uses_detailed_status_endpoint(credential_path):
+    CredentialStore.save(
+        {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
+    )
+    client = SkyportalClient("https://app.skyportal.ai")
+    payload = {"status": "processing", "current_step": "Inspect logs"}
+
+    with patch("skyportal.portal.urlopen", return_value=FakeResponse(payload)) as request_call:
+        assert client.get_execution_status(42) == payload
+
+    request = request_call.call_args.args[0]
+    assert request.full_url.endswith("/api/v1/agent/chat/42/execution-status/")
+
+
 def test_wait_for_chat_polls_and_returns_message_cursor(credential_path):
     client = SkyportalClient("https://app.skyportal.ai")
-    messages = {
-        "messages": [
-            {"sequence": 4, "role": "user", "content": [{"type": "text", "text": "Hi"}]},
-            {
-                "sequence": 5,
-                "role": "assistant",
-                "content": [{"type": "text", "text": "Hello"}],
-            },
-        ],
-        "has_more": False,
+    busy_message = {
+        "sequence": 4,
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Checking"}],
+    }
+    terminal_message = {
+        "sequence": 5,
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello"}],
     }
 
     with patch.object(
         client,
         "chat_status",
         side_effect=[
-            {"status": "uninitialized", "pending_approvals": []},
             {"status": "processing", "pending_approvals": []},
             {"status": "idle", "pending_approvals": []},
         ],
-    ), patch.object(client, "chat_messages", return_value=messages) as get_messages, patch(
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [busy_message], "has_more": False},
+            {"messages": [terminal_message], "has_more": False},
+        ],
+    ) as get_messages, patch.object(client, "get_execution_status") as detailed_status, patch(
         "skyportal.portal.time.sleep"
     ):
         result = client.wait_for_chat(42, after_sequence=3, poll_interval=0)
@@ -307,11 +326,128 @@ def test_wait_for_chat_polls_and_returns_message_cursor(credential_path):
     assert result == ChatTurnResult(
         chat_id=42,
         status="idle",
-        messages=messages["messages"],
+        messages=[busy_message, terminal_message],
         pending_approvals=[],
         latest_sequence=5,
     )
-    get_messages.assert_called_once_with(42, after_sequence=3)
+    assert get_messages.call_args_list == [
+        call(42, after_sequence=3),
+        call(42, after_sequence=4),
+    ]
+    detailed_status.assert_not_called()
+
+
+def test_wait_for_chat_streams_only_new_messages_and_returns_all_observed_messages(
+    credential_path,
+):
+    client = SkyportalClient("https://app.skyportal.ai")
+    first = {"sequence": 4, "role": "assistant", "content": "first"}
+    second = {"sequence": 5, "role": "tool", "content": "second"}
+    final = {"sequence": 6, "role": "assistant", "content": "final"}
+    delivered = []
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [first], "has_more": False},
+            # Deliberately replay sequence 4 even though the cursor is 4.
+            {"messages": [first, second, second], "has_more": False},
+            {"messages": [final], "has_more": False},
+        ],
+    ) as get_messages, patch.object(client, "get_execution_status") as detailed_status, patch(
+        "skyportal.portal.time.sleep"
+    ):
+        result = client.wait_for_chat(
+            42,
+            after_sequence=3,
+            poll_interval=0,
+            on_progress=delivered.append,
+        )
+
+    assert delivered == [[first], [second]]
+    assert result.messages == [first, second, final]
+    assert result.latest_sequence == 6
+    assert get_messages.call_args_list == [
+        call(42, after_sequence=3),
+        call(42, after_sequence=4),
+        call(42, after_sequence=5),
+    ]
+    detailed_status.assert_not_called()
+
+
+def test_wait_for_chat_preserves_batch_when_progress_callback_fails(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    message = {"sequence": 4, "role": "assistant", "content": "still visible"}
+
+    def fail_to_render(_messages):
+        raise RuntimeError("renderer failed")
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [message], "has_more": False},
+            {"messages": [], "has_more": False},
+            {"messages": [], "has_more": False},
+            {"messages": [], "has_more": False},
+            {"messages": [], "has_more": False},
+            {"messages": [], "has_more": False},
+        ],
+    ), patch("skyportal.portal.time.sleep"):
+        result = client.wait_for_chat(
+            42,
+            after_sequence=3,
+            poll_interval=0,
+            on_progress=fail_to_render,
+        )
+
+    assert result.messages == [message]
+    assert result.latest_sequence == 4
+
+
+def test_wait_for_chat_retries_once_when_only_earlier_messages_were_observed(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    prompt = {"sequence": 4, "role": "user", "content": "inspect the host"}
+    final = {"sequence": 5, "role": "assistant", "content": "finished"}
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [prompt], "has_more": False},
+            {"messages": [], "has_more": False},
+            {"messages": [final], "has_more": False},
+        ],
+    ) as get_messages, patch("skyportal.portal.time.sleep") as sleep:
+        result = client.wait_for_chat(42, after_sequence=3, poll_interval=0)
+
+    assert result.messages == [prompt, final]
+    assert get_messages.call_count == 3
+    # Main poll plus exactly one short terminal-settlement retry.
+    assert [item.args[0] for item in sleep.call_args_list] == [0, 0.25]
 
 
 def test_wait_for_chat_retries_when_first_fetch_is_empty(credential_path):
@@ -319,9 +455,8 @@ def test_wait_for_chat_retries_when_first_fetch_is_empty(credential_path):
     awaiting_input) before the message that justifies it is queryable via
     chat_messages() — a fast, LLM-free turn (one host-collection step) can
     win that race and come back empty on the first fetch. wait_for_chat
-    must keep retrying (with backoff, bounded by the same deadline as the
-    status poll) rather than report an empty turn for a response that
-    exists but isn't visible yet."""
+    must keep retrying with its own bounded settlement budget rather than
+    report an empty turn for a response that exists but isn't visible yet."""
     client = SkyportalClient("https://app.skyportal.ai")
     real_messages = {
         "messages": [
@@ -331,17 +466,11 @@ def test_wait_for_chat_retries_when_first_fetch_is_empty(credential_path):
     }
     empty_messages = {"messages": [], "has_more": False}
 
-    # monotonic() is called once for the initial deadline, then once per
-    # loop-condition check in each while loop — keep it comfortably inside
-    # the deadline throughout so the retry loop runs on chat_messages'
-    # side_effect exhausting, not on hitting the (mocked) clock.
     with patch.object(
         client, "chat_status", return_value={"status": "awaiting_input", "pending_approvals": []},
     ), patch.object(
         client, "chat_messages", side_effect=[empty_messages, empty_messages, real_messages],
-    ) as get_messages, patch("skyportal.portal.time.sleep") as sleep, patch(
-        "skyportal.portal.time.monotonic", return_value=0.0,
-    ):
+    ) as get_messages, patch("skyportal.portal.time.sleep") as sleep:
         result = client.wait_for_chat(983, after_sequence=10, poll_interval=0, timeout=300)
 
     assert result.messages == real_messages["messages"]
@@ -351,33 +480,181 @@ def test_wait_for_chat_retries_when_first_fetch_is_empty(credential_path):
     assert [call.args[0] for call in sleep.call_args_list] == [0.25, 0.5]
 
 
-def test_wait_for_chat_gives_up_at_deadline_on_genuinely_empty_turn(credential_path):
-    """A turn that really did produce no new messages must still return an
-    empty result once the deadline passes, not hang or raise."""
+def test_wait_for_chat_terminal_message_settlement_is_independently_bounded(credential_path):
     client = SkyportalClient("https://app.skyportal.ai")
     empty_messages = {"messages": [], "has_more": False}
-
-    # First monotonic() call sets the deadline (0.0 + timeout); the status
-    # loop's own condition check needs to stay under that deadline so
-    # chat_status() gets a chance to report "idle" and break out normally.
-    # Only once we reach the messages-retry loop does the clock jump past
-    # the deadline, so it exits on its first empty fetch instead of
-    # looping (or sleeping) in the test.
-    clock = iter([0.0, 0.1] + [1000.0] * 10)
 
     with patch.object(
         client, "chat_status", return_value={"status": "idle", "pending_approvals": []},
     ), patch.object(
         client, "chat_messages", return_value=empty_messages,
     ) as get_messages, patch("skyportal.portal.time.sleep") as sleep, patch(
-        "skyportal.portal.time.monotonic", side_effect=lambda: next(clock),
+        "skyportal.portal.time.monotonic", return_value=0.0,
     ):
         result = client.wait_for_chat(983, after_sequence=10, poll_interval=0, timeout=1)
 
     assert result.messages == []
     assert result.latest_sequence == 10
-    assert get_messages.call_count == 1
+    assert get_messages.call_count == 5
+    assert [item.args[0] for item in sleep.call_args_list] == [0.25, 0.5, 1.0, 2.0]
+
+
+@pytest.mark.parametrize("status", ["awaiting_approval", "error"])
+def test_wait_for_chat_approval_and_error_return_after_one_message_fetch(
+    credential_path,
+    status,
+):
+    client = SkyportalClient("https://app.skyportal.ai")
+    pending = [{"approval_id": "a1"}] if status == "awaiting_approval" else []
+
+    with patch.object(
+        client,
+        "chat_status",
+        return_value={"status": status, "pending_approvals": pending},
+    ), patch.object(
+        client,
+        "chat_messages",
+        return_value={"messages": [], "has_more": False},
+    ) as get_messages, patch("skyportal.portal.time.sleep") as sleep:
+        result = client.wait_for_chat(42, after_sequence=7)
+
+    assert result.status == status
+    assert result.pending_approvals == pending
+    get_messages.assert_called_once_with(42, after_sequence=7)
     sleep.assert_not_called()
+
+
+def test_wait_for_chat_new_messages_extend_idle_deadline(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    now = [0.0]
+    progress = {"sequence": 4, "role": "assistant", "content": "working"}
+    final = {"sequence": 5, "role": "assistant", "content": "done"}
+
+    def advance(seconds):
+        now[0] += seconds
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [], "has_more": False},
+            {"messages": [progress], "has_more": False},
+            {"messages": [final], "has_more": False},
+        ],
+    ), patch("skyportal.portal.time.monotonic", side_effect=lambda: now[0]), patch(
+        "skyportal.portal.time.sleep", side_effect=advance
+    ):
+        result = client.wait_for_chat(42, after_sequence=3, timeout=3, poll_interval=2)
+
+    # The second poll's new message at t=2 extends the original t=3 deadline,
+    # allowing the terminal status to be observed at t=4.
+    assert result.messages == [progress, final]
+    assert result.latest_sequence == 5
+
+
+def test_wait_for_chat_duplicate_message_snapshot_does_not_extend_idle_deadline(
+    credential_path,
+):
+    client = SkyportalClient("https://app.skyportal.ai")
+    now = [0.0]
+    progress = {"sequence": 4, "role": "assistant", "content": "working"}
+    delivered = []
+
+    def advance(seconds):
+        now[0] += seconds
+
+    with patch.object(
+        client,
+        "chat_status",
+        return_value={"status": "processing", "pending_approvals": []},
+    ) as get_status, patch.object(
+        client,
+        "chat_messages",
+        return_value={"messages": [progress], "has_more": False},
+    ) as get_messages, patch("skyportal.portal.time.monotonic", side_effect=lambda: now[0]), patch(
+        "skyportal.portal.time.sleep", side_effect=advance
+    ):
+        with pytest.raises(PortalError, match="no progress for 3 seconds"):
+            client.wait_for_chat(
+                42,
+                after_sequence=3,
+                timeout=3,
+                poll_interval=2,
+                on_progress=delivered.append,
+            )
+
+    assert delivered == [[progress]]
+    assert get_status.call_count == 2
+    assert get_messages.call_args_list == [
+        call(42, after_sequence=3),
+        call(42, after_sequence=4),
+    ]
+
+
+def test_wait_for_chat_status_transition_extends_idle_deadline(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    now = [0.0]
+    final = {"sequence": 1, "role": "assistant", "content": "done"}
+
+    def advance(seconds):
+        now[0] += seconds
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "uninitialized", "pending_approvals": []},
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [], "has_more": False},
+            {"messages": [], "has_more": False},
+            {"messages": [final], "has_more": False},
+        ],
+    ), patch("skyportal.portal.time.monotonic", side_effect=lambda: now[0]), patch(
+        "skyportal.portal.time.sleep", side_effect=advance
+    ):
+        result = client.wait_for_chat(42, timeout=3, poll_interval=2)
+
+    assert result.messages == [final]
+
+
+def test_wait_for_chat_default_disables_idle_deadline(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    final = {"sequence": 1, "role": "assistant", "content": "done"}
+
+    with patch.object(
+        client,
+        "chat_status",
+        side_effect=[
+            {"status": "processing", "pending_approvals": []},
+            {"status": "idle", "pending_approvals": []},
+        ],
+    ), patch.object(
+        client,
+        "chat_messages",
+        side_effect=[
+            {"messages": [], "has_more": False},
+            {"messages": [final], "has_more": False},
+        ],
+    ), patch("skyportal.portal.time.monotonic", side_effect=AssertionError("deadline used")), patch(
+        "skyportal.portal.time.sleep"
+    ):
+        result = client.wait_for_chat(42, poll_interval=0)
+
+    assert result.messages == [final]
 
 
 def test_run_chat_turn_continues_existing_chat(credential_path):
@@ -396,7 +673,37 @@ def test_run_chat_turn_continues_existing_chat(credential_path):
 
     assert result is completed
     send.assert_called_once_with(42, "Continue")
-    wait.assert_called_once_with(42, after_sequence=8, timeout=300, poll_interval=0)
+    wait.assert_called_once_with(
+        42,
+        after_sequence=8,
+        timeout=None,
+        poll_interval=0,
+        on_progress=None,
+    )
+
+
+def test_run_chat_turn_forwards_progress_callback(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    completed = ChatTurnResult(42, "idle", [], [], 9)
+    progress_batches = []
+
+    with patch.object(client, "begin_chat_turn", return_value=42), patch.object(
+        client, "wait_for_chat", return_value=completed
+    ) as wait:
+        result = client.run_chat_turn(
+            "Continue",
+            chat_id=42,
+            on_progress=progress_batches.append,
+        )
+
+    assert result is completed
+    wait.assert_called_once_with(
+        42,
+        after_sequence=0,
+        timeout=None,
+        poll_interval=1,
+        on_progress=progress_batches.append,
+    )
 
 
 def test_approval_and_server_selection_use_headless_endpoints(credential_path):
@@ -412,6 +719,13 @@ def test_approval_and_server_selection_use_headless_endpoints(credential_path):
             "approved",
         )
         approval_request = call.call_args.args[0]
+        client.submit_chat_approval(
+            42,
+            {"approval_id": "auto", "type": "plan"},
+            "approved",
+            autoapproved=True,
+        )
+        autoapproval_request = call.call_args.args[0]
         client.select_chat_server(42, 7)
         server_request = call.call_args.args[0]
 
@@ -422,6 +736,11 @@ def test_approval_and_server_selection_use_headless_endpoints(credential_path):
         "decision": "approved",
         "type": "bash_command",
         "command": "df -h",
+    }
+    assert json.loads(autoapproval_request.data) == {
+        "decision": "approved",
+        "type": "plan",
+        "autoapproved": True,
     }
     assert server_request.full_url.endswith("/api/v1/agent/chat/42/select-server/")
     assert json.loads(server_request.data) == {"server_id": 7}
@@ -488,6 +807,17 @@ def test_missing_credentials_are_reported(credential_path):
 
     with pytest.raises(PortalError, match="Not connected"):
         client.servers()
+
+
+def test_raw_request_timeout_is_wrapped_as_portal_error(credential_path):
+    CredentialStore.save(
+        {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
+    )
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch("skyportal.portal.urlopen", side_effect=TimeoutError("timed out")):
+        with pytest.raises(PortalError, match="request timed out"):
+            client.servers()
 
 
 def test_credentials_are_scoped_to_deployment(credential_path):
@@ -644,3 +974,42 @@ def test_delete_github_token_calls_delete_endpoint(credential_path):
     request = call.call_args.args[0]
     assert request.method == "DELETE"
     assert request.full_url == "https://app.skyportal.ai/api/v1/agent/github-token/delete/"
+
+
+def test_get_permission_mode_uses_shared_account_endpoint(credential_path):
+    CredentialStore.save(
+        {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
+    )
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch(
+        "skyportal.portal.urlopen",
+        return_value=FakeResponse({"permission_mode": "ask", "read_only_mode": False}),
+    ) as call:
+        assert client.get_permission_mode() == "ask"
+
+    request = call.call_args.args[0]
+    assert request.method == "GET"
+    assert request.full_url == "https://app.skyportal.ai/api/v1/agent/permission/"
+
+
+def test_set_permission_mode_puts_only_supported_mode(credential_path):
+    CredentialStore.save(
+        {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}
+    )
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch(
+        "skyportal.portal.urlopen",
+        return_value=FakeResponse({"permission_mode": "autoapprove"}),
+    ) as call:
+        assert client.set_permission_mode("autoapprove") == "autoapprove"
+
+    request = call.call_args.args[0]
+    assert request.method == "PUT"
+    assert json.loads(request.data) == {"permission_mode": "autoapprove"}
+
+    with patch("skyportal.portal.urlopen") as invalid_call:
+        with pytest.raises(PortalError, match="ask.*autoapprove"):
+            client.set_permission_mode("everything")
+    invalid_call.assert_not_called()

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -582,11 +582,11 @@ def test_wait_for_chat_duplicate_message_snapshot_does_not_extend_idle_deadline(
     ) as get_messages, patch("skyportal.portal.time.monotonic", side_effect=lambda: now[0]), patch(
         "skyportal.portal.time.sleep", side_effect=advance
     ):
-        with pytest.raises(PortalError, match="no progress for 3 seconds"):
+        with pytest.raises(PortalError, match="no progress for 3.5 seconds"):
             client.wait_for_chat(
                 42,
                 after_sequence=3,
-                timeout=3,
+                timeout=3.5,
                 poll_interval=2,
                 on_progress=delivered.append,
             )

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -28,8 +28,8 @@ class FakeClient:
         self.begin_calls.append((message, chat_id, server_id))
         return chat_id if chat_id is not None else 100
 
-    def wait_for_chat(self, chat_id, after_sequence=0):
-        self.wait_calls.append((chat_id, after_sequence))
+    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+        self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
         if self._wait_raises is not None:
             raise self._wait_raises
         return self._wait_result

--- a/tests/test_shell_multihost.py
+++ b/tests/test_shell_multihost.py
@@ -15,6 +15,10 @@ class FakeClient:
         self.scope_calls = []
         self.single_scope_calls = []
         self.begin_calls = []
+        self.wait_calls = []
+        self.submit_calls = []
+        self.permission_mode = "ask"
+        self.wait_results = []
 
     def is_authenticated(self):
         return True
@@ -63,8 +67,22 @@ class FakeClient:
         )
         return chat_id if chat_id is not None else 100
 
-    def wait_for_chat(self, chat_id, after_sequence=0):
+    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+        self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
+        if self.wait_results:
+            return self.wait_results.pop(0)
         return ChatTurnResult(chat_id, "idle", [], [], after_sequence)
+
+    def get_permission_mode(self):
+        return self.permission_mode
+
+    def submit_chat_approval(
+        self, chat_id, approval, decision, *, autoapproved=False
+    ):
+        self.submit_calls.append(
+            (chat_id, approval["approval_id"], decision, autoapproved)
+        )
+        return {"success": True}
 
 
 @pytest.fixture
@@ -126,6 +144,31 @@ def test_single_server_existing_chat_uses_legacy_singular_endpoint(shell):
     assert client.single_scope_calls == [(42, 7)]
     assert client.scope_calls == []
     assert instance.selected_server_ids == [7]
+
+
+def test_multihost_scope_survives_autoapproval_resume_with_indefinite_wait(shell):
+    instance, client, _console = shell
+    instance.chat_id = 42
+    instance.selected_server_ids = [7, 9]
+    instance.selected_server_id = 7
+    client.permission_mode = "autoapprove"
+    client.wait_results = [ChatTurnResult(42, "idle", [], [], 0)]
+    approval = {
+        "approval_id": "multi-1",
+        "type": "bash_command",
+        "command": "hostname",
+    }
+
+    instance._process_turn(
+        ChatTurnResult(42, "awaiting_approval", [], [approval], 0)
+    )
+
+    assert instance.selected_server_ids == [7, 9]
+    assert instance.selected_server_id == 7
+    assert client.scope_calls == []
+    assert client.submit_calls == [(42, "multi-1", "approved", True)]
+    assert client.wait_calls[0][0:3] == (42, 0, None)
+    assert client.wait_calls[0][3] is not None
 
 
 def test_auto_explicitly_clears_existing_chat_scope(shell):

--- a/tests/test_shell_permission.py
+++ b/tests/test_shell_permission.py
@@ -1,0 +1,237 @@
+"""Shared approval-policy behavior in the interactive legacy CLI."""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from prompt_toolkit.document import Document
+from rich.console import Console
+
+from skyportal.portal import ChatTurnResult, PortalError
+from skyportal.shell import COMMANDS, InteractiveShell, SkyportalCompleter
+
+
+class _Session:
+    def __init__(self, answers=()):
+        self._answers = iter(answers)
+        self.calls = 0
+
+    def prompt(self, _message):
+        self.calls += 1
+        return next(self._answers)
+
+
+class PermissionClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(
+        self,
+        mode="ask",
+        wait_results=(),
+        permission_error=None,
+        autoapproval_conflict=False,
+    ):
+        self.mode = mode
+        self.wait_results = iter(wait_results)
+        self.permission_error = permission_error
+        self.autoapproval_conflict = autoapproval_conflict
+        self.get_calls = 0
+        self.set_calls = []
+        self.submit_calls = []
+        self.wait_calls = []
+
+    def is_authenticated(self):
+        return True
+
+    def get_permission_mode(self):
+        self.get_calls += 1
+        if self.permission_error is not None:
+            raise self.permission_error
+        return self.mode
+
+    def set_permission_mode(self, mode):
+        self.set_calls.append(mode)
+        self.mode = mode
+        return mode
+
+    def submit_chat_approval(
+        self, chat_id, approval, decision, *, autoapproved=False
+    ):
+        self.submit_calls.append(
+            (chat_id, approval["approval_id"], decision, autoapproved)
+        )
+        if autoapproved and self.autoapproval_conflict:
+            raise PortalError(
+                "Autoapproval is no longer enabled",
+                status_code=409,
+                code="autoapproval_policy_conflict",
+            )
+        return {"success": True}
+
+    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+        self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
+        return next(self.wait_results)
+
+
+def _shell(client, tmp_path, monkeypatch, session=None):
+    monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    console = Console(file=StringIO(), force_terminal=False, width=160)
+    shell = InteractiveShell(
+        console=console,
+        client_factory=lambda: client,
+        session=session or _Session(),
+        token_prompt=lambda _prompt: "",
+    )
+    return shell, console
+
+
+def _turn(status, approvals=()):
+    return ChatTurnResult(
+        chat_id=42,
+        status=status,
+        messages=[],
+        pending_approvals=list(approvals),
+        latest_sequence=0,
+    )
+
+
+def test_permission_command_gets_and_sets_shared_mode(tmp_path, monkeypatch):
+    client = PermissionClient(mode="ask")
+    shell, console = _shell(client, tmp_path, monkeypatch)
+
+    shell._cmd_permission([])
+    shell._cmd_permission(["autoapprove"])
+    shell._cmd_status([])
+
+    output = console.file.getvalue()
+    assert "Permission mode: ask" in output
+    assert "Permission mode: autoapprove" in output
+    assert "autoapprove" in output
+    assert client.set_calls == ["autoapprove"]
+    assert client.get_calls == 2  # bare /permission and /status both refresh
+
+
+def test_permission_help_handler_and_completions_are_registered(tmp_path, monkeypatch):
+    shell, _console = _shell(PermissionClient(), tmp_path, monkeypatch)
+
+    assert "/permission" in COMMANDS
+    assert "/permission" in shell._handlers
+    completions = [
+        item.text
+        for item in SkyportalCompleter().get_completions(Document("/permission a"), None)
+    ]
+    assert completions == ["autoapprove", "ask"]
+
+
+def test_permission_rejects_unknown_mode_without_writing(tmp_path, monkeypatch):
+    client = PermissionClient()
+    shell, console = _shell(client, tmp_path, monkeypatch)
+
+    shell._cmd_permission(["everything"])
+
+    assert "Usage:" in console.file.getvalue()
+    assert client.set_calls == []
+
+
+def test_autoapprove_waits_out_stale_snapshot_then_approves_next_id_once(
+    tmp_path, monkeypatch
+):
+    first = {"approval_id": "a1", "type": "bash_command", "command": "uptime"}
+    second = {"approval_id": "a2", "type": "plan", "reason": "apply plan"}
+    client = PermissionClient(
+        mode="autoapprove",
+        wait_results=(
+            _turn("awaiting_approval", (first, second)),  # stale: a1 still present
+            _turn("awaiting_approval", (second,)),
+            _turn("idle"),
+        ),
+    )
+    session = _Session()
+    shell, console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    with patch("skyportal.shell.time.sleep") as sleep:
+        shell._process_turn(_turn("awaiting_approval", (first, second)))
+
+    assert session.calls == 0
+    assert client.submit_calls == [
+        (42, "a1", "approved", True),
+        (42, "a2", "approved", True),
+    ]
+    assert len(client.wait_calls) == 3
+    assert sleep.call_count == 1
+    assert console.file.getvalue().count("Auto-approving") == 2
+
+
+def test_autoapprove_mode_failure_falls_back_to_prompt(tmp_path, monkeypatch):
+    approval = {"approval_id": "a1", "type": "bash_command", "command": "uptime"}
+    client = PermissionClient(
+        permission_error=PortalError("permission endpoint unavailable"),
+        wait_results=(_turn("idle"),),
+    )
+    session = _Session(["y"])
+    shell, console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    shell._process_turn(_turn("awaiting_approval", (approval,)))
+
+    assert session.calls == 1
+    assert client.submit_calls == [(42, "a1", "approved", False)]
+    assert "asking for safety" in console.file.getvalue()
+
+
+def test_autoapprove_policy_race_reprompts_and_submits_unmarked_manual_decision(
+    tmp_path, monkeypatch
+):
+    approval = {"approval_id": "a1", "type": "bash_command", "command": "uptime"}
+    client = PermissionClient(
+        mode="autoapprove",
+        autoapproval_conflict=True,
+        wait_results=(_turn("idle"),),
+    )
+    session = _Session(["y"])
+    shell, console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    shell._process_turn(_turn("awaiting_approval", (approval,)))
+
+    assert session.calls == 1
+    assert client.submit_calls == [
+        (42, "a1", "approved", True),
+        (42, "a1", "approved", False),
+    ]
+    assert "explicit decision is required" in console.file.getvalue()
+
+
+def test_autoapprove_does_not_silently_coerce_unknown_approval_type(
+    tmp_path, monkeypatch
+):
+    approval = {
+        "approval_id": "future-1",
+        "type": "future_privileged_action",
+        "reason": "new action type",
+    }
+    client = PermissionClient(mode="autoapprove", wait_results=(_turn("idle"),))
+    session = _Session(["n"])
+    shell, console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    shell._process_turn(_turn("awaiting_approval", (approval,)))
+
+    assert client.get_calls == 0
+    assert session.calls == 1
+    assert client.submit_calls == [(42, "future-1", "rejected", False)]
+    assert "requires an explicit decision" in console.file.getvalue()
+
+
+def test_malformed_first_approval_is_not_skipped_or_coerced(
+    tmp_path, monkeypatch
+):
+    malformed = {"approval_id": None, "type": "bash_command"}
+    later = {"approval_id": "a2", "type": "bash_command", "command": "uptime"}
+    client = PermissionClient(mode="autoapprove")
+    session = _Session(["y"])
+    shell, _console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    with pytest.raises(PortalError, match="without an approval ID"):
+        shell._process_turn(_turn("awaiting_approval", (malformed, later)))
+
+    assert client.get_calls == 0
+    assert client.submit_calls == []
+    assert session.calls == 0

--- a/tests/test_shell_streaming.py
+++ b/tests/test_shell_streaming.py
@@ -1,0 +1,273 @@
+"""Incremental legacy-shell rendering, approval recovery, and remote status."""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from skyportal.portal import ChatTurnResult, PortalError
+from skyportal.shell import InteractiveShell
+
+
+def _assistant(text, sequence):
+    return {
+        "role": "assistant",
+        "sequence": sequence,
+        "content": [{"type": "text", "text": text}],
+        "metadata": {},
+    }
+
+
+def _tool(command, output, sequence):
+    return {
+        "role": "tool",
+        "sequence": sequence,
+        "content": [{"type": "text", "text": output}],
+        "metadata": {
+            "terminal_command": command,
+            "terminal_output": output,
+            "terminal_server_hostname": "web-1",
+            "terminal_success": True,
+        },
+    }
+
+
+class _Session:
+    def __init__(self, answers=()):
+        self.answers = iter(answers)
+        self.calls = 0
+
+    def prompt(self, _message):
+        self.calls += 1
+        return next(self.answers)
+
+
+def _shell(client, tmp_path, monkeypatch, session=None):
+    monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    console = Console(file=StringIO(), force_terminal=False, width=200)
+    shell = InteractiveShell(
+        console=console,
+        client_factory=lambda: client,
+        session=session or _Session(),
+        token_prompt=lambda _prompt: "",
+    )
+    return shell, console
+
+
+class StreamingClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self):
+        self.wait_calls = []
+
+    def is_authenticated(self):
+        return True
+
+    def begin_chat_turn(self, message, chat_id=None, server_id=None):
+        return chat_id or 42
+
+    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+        self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
+        first = _assistant("streamed first", 1)
+        second = _tool("uptime", "up 10 days", 2)
+        assert on_progress is not None
+        on_progress([first])
+        on_progress([first, second])  # replayed sequence 1 must not render twice
+        return ChatTurnResult(
+            chat_id=chat_id,
+            status="idle",
+            messages=[second, _assistant("streamed final", 3)],
+            pending_approvals=[],
+            latest_sequence=3,
+        )
+
+    def cancel_chat(self, chat_id, reason=None):
+        return {"status": "cancelled"}
+
+
+def test_shell_waits_indefinitely_and_renders_each_persisted_message_once(
+    tmp_path, monkeypatch
+):
+    client = StreamingClient()
+    shell, console = _shell(client, tmp_path, monkeypatch)
+
+    shell._send_prompt("inspect the host")
+
+    output = console.file.getvalue()
+    assert output.count("streamed first") == 1
+    assert output.count("up 10 days") == 1
+    assert output.count("streamed final") == 1
+    assert output.count("Skyportal agent") == 1
+    assert client.wait_calls[0][2] is None
+    assert shell.last_sequence == 3
+
+
+def test_failed_progress_render_is_retried_from_final_result(tmp_path, monkeypatch):
+    shell, _console = _shell(StreamingClient(), tmp_path, monkeypatch)
+    state = shell._new_render_state()
+    message = _assistant("retry me", 9)
+
+    with patch.object(
+        shell,
+        "_render_assistant_messages",
+        side_effect=[RuntimeError("console failed"), True],
+    ) as render:
+        with pytest.raises(RuntimeError, match="console failed"):
+            shell._render_incremental_messages([message], state)
+        assert state["seen"] == set()
+        assert shell.last_sequence == 0
+
+        shell._render_incremental_messages([message], state)
+
+    assert render.call_count == 2
+    assert shell.last_sequence == 9
+
+
+class ApprovalClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self, *, stale=False):
+        self.stale = stale
+        self.submit_calls = []
+        self.status_calls = []
+        self.wait_calls = []
+
+    def is_authenticated(self):
+        return True
+
+    def submit_chat_approval(self, chat_id, approval, decision):
+        self.submit_calls.append((chat_id, approval, decision))
+        if not self.stale:
+            raise PortalError("Could not connect to Skyportal: timed out")
+        return {"success": True}
+
+    def chat_status(self, chat_id):
+        self.status_calls.append(chat_id)
+        return {"status": "processing", "pending_approvals": []}
+
+    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+        self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
+        if self.stale:
+            approval = {"approval_id": "approval-1", "command": "uptime"}
+            return ChatTurnResult(
+                chat_id, "awaiting_approval", [], [approval], after_sequence
+            )
+        message = _assistant("continued exactly once", 5)
+        assert on_progress is not None
+        on_progress([message])
+        return ChatTurnResult(chat_id, "idle", [message], [], 5)
+
+
+def _approval_turn():
+    approval = {"approval_id": "approval-1", "command": "uptime"}
+    return ChatTurnResult(42, "awaiting_approval", [], [approval], 4)
+
+
+def test_approval_timeout_reconciles_without_resubmitting(tmp_path, monkeypatch):
+    client = ApprovalClient()
+    session = _Session(["y"])
+    shell, console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    shell._process_turn(_approval_turn())
+
+    assert len(client.submit_calls) == 1
+    assert client.status_calls == [42]
+    assert client.wait_calls[0][2] is None
+    assert console.file.getvalue().count("continued exactly once") == 1
+    assert "reattached" in console.file.getvalue()
+
+
+def test_stale_approval_snapshot_is_not_prompted_or_submitted_twice(
+    tmp_path, monkeypatch
+):
+    client = ApprovalClient(stale=True)
+    session = _Session(["y", "y"])
+    shell, _console = _shell(client, tmp_path, monkeypatch, session=session)
+
+    with patch("skyportal.shell.time.monotonic", side_effect=[0.0, 301.0]):
+        with pytest.raises(PortalError, match="will not be submitted twice"):
+            shell._process_turn(_approval_turn())
+
+    assert session.calls == 1
+    assert len(client.submit_calls) == 1
+
+
+class StatusClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self, payload=None, error=None, authenticated=True):
+        self.payload = payload or {}
+        self.error = error
+        self.authenticated = authenticated
+        self.execution_calls = []
+        self.status_calls = []
+
+    def is_authenticated(self):
+        return self.authenticated
+
+    def get_execution_status(self, chat_id):
+        self.execution_calls.append(chat_id)
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+    def chat_status(self, chat_id):
+        self.status_calls.append(chat_id)
+        return {"status": "awaiting_approval", "pending_approvals": []}
+
+
+def test_status_shows_remote_workflow_command_and_approval_without_raw_output(
+    tmp_path, monkeypatch
+):
+    client = StatusClient(
+        {
+            "status": "processing",
+            "pending_approvals": [
+                {"approval_id": "a1", "command": "[red]restart web[/red]"}
+            ],
+            "live_command_output": {
+                "command": "printf '[bold]hello[/bold]'",
+                "output": "RAW-SECRET-MUST-NOT-BE-DISPLAYED",
+            },
+            "live_plan": {"current_step_index": 1, "total_steps": 4},
+        }
+    )
+    shell, console = _shell(client, tmp_path, monkeypatch)
+    shell.chat_id = 42
+
+    shell._cmd_status([])
+
+    output = console.file.getvalue()
+    assert "processing" in output
+    assert "restart web" in output
+    assert "printf '[bold]hello[/bold]'" in output
+    assert "step 2/4" in output
+    assert "RAW-SECRET-MUST-NOT-BE-DISPLAYED" not in output
+    assert client.execution_calls == [42]
+
+
+def test_status_falls_back_to_lightweight_endpoint_on_older_server(
+    tmp_path, monkeypatch
+):
+    client = StatusClient(error=PortalError("missing", status_code=404))
+    shell, console = _shell(client, tmp_path, monkeypatch)
+    shell.chat_id = 17
+
+    shell._cmd_status([])
+
+    assert "awaiting_approval" in console.file.getvalue()
+    assert client.execution_calls == [17]
+    assert client.status_calls == [17]
+
+
+def test_status_without_authenticated_chat_does_not_make_remote_request(
+    tmp_path, monkeypatch
+):
+    client = StatusClient(authenticated=False)
+    shell, _console = _shell(client, tmp_path, monkeypatch)
+
+    shell._cmd_status([])
+
+    assert client.execution_calls == []
+    assert client.status_calls == []

--- a/tests/test_shell_tool_rendering.py
+++ b/tests/test_shell_tool_rendering.py
@@ -111,9 +111,35 @@ class TestToolResultLine:
         assert ok_line.plain != fail_line.plain
 
     def test_long_output_is_truncated(self):
-        long_output = "x" * 500
+        long_output = "x" * 6000
         line = InteractiveShell._tool_result_line(_tool_message(output=long_output))
-        assert len(line.plain) < 500
+        assert len(line.plain) < len(long_output)
+        assert "output truncated" in line.plain
+
+    def test_multiline_inventory_output_remains_useful(self):
+        output = "\n".join("field-{}: value".format(index) for index in range(16))
+
+        line = InteractiveShell._tool_result_line(_tool_message(output=output))
+
+        assert line is not None
+        assert "field-0: value" in line.plain
+        assert "field-15: value" in line.plain
+        assert "output truncated" not in line.plain
+
+    def test_server_text_is_literal_and_terminal_controls_are_removed(self):
+        line = InteractiveShell._tool_result_line(
+            _tool_message(
+                hostname="[red]host[/red]",
+                command="printf '[bold]not markup[/bold]'",
+                output="\x1b[31m[green]literal[/green]\x1b[0m",
+            )
+        )
+
+        assert line is not None
+        assert "[red]host[/red]" in line.plain
+        assert "[bold]not markup[/bold]" in line.plain
+        assert "[green]literal[/green]" in line.plain
+        assert "\x1b" not in line.plain
 
 
 class TestRenderAssistantMessagesIncludesToolLines:


### PR DESCRIPTION
- Introduced tests for permission mode retrieval and setting in `test_client_config.py`.
- Enhanced `test_portal.py` with detailed tests for chat execution status and message handling.
- Updated `test_shell_cancel.py` and `test_shell_multihost.py` to accommodate new chat wait parameters.
- Added comprehensive tests for permission command behavior in `test_shell_permission.py`.
- Implemented streaming message handling and approval recovery in `test_shell_streaming.py`.
- Improved output handling and error management in various shell tests.

## Change type

Select **all** that apply and fill in the corresponding section(s) below.
Sections whose type is **not** checked may be left as-is.

- [ ] 🆕 New or changed CLI command / flag
- [ ] 🔄 Behavior change (observable difference for users)
- [ ] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

Describe the problem and the approach taken.

---

<!-- ✅ Required when "New or changed CLI command / flag" is checked -->
## CLI usage example

> **Required for new/changed commands or flags.**
> Show the command(s) as a user would type them, including representative
> options, and note which documentation page was updated.

```
# before (omit if this is a brand-new command)
skyportalai <old-command> [flags]

# after
skyportalai <new-command> [flags]
```

Docs updated: <!-- path(s) or "N/A – no public docs affected" -->

---

<!-- ✅ Required when "Behavior change" is checked -->
## Before / after

> **Required for behavior changes.**
> Describe what users experienced before and what they experience after.

**Before:** <!-- observable behavior or output -->

**After:** <!-- observable behavior or output -->

Test coverage: <!-- new/updated test file(s) or "covered by existing tests" -->

---

<!-- ✅ Required when "Security-sensitive change" is checked -->
## Security callout

> **Required for auth, credentials, kubeconfig, or secrets handling.**
> Explain the threat model impact of this change.

**What changed in security-sensitive code:**

**Why it is safe / how the risk is mitigated:**

**Credentials or secrets introduced:** None <!-- or describe and justify -->

---

<!-- ✅ Standard checklist – always complete this section -->
## Validation

- [ ] Tests added or updated where behavior changed
- [ ] `poetry run pytest` passes
- [ ] `poetry run ruff check .` passes
- [ ] Public API/configuration changes are documented
- [ ] No credentials or private run data are included

## Related issue

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared approval policy controls via `/permission ask|autoapprove`, with SDK and CLI support for permission mode.
  * Added configurable chat progress rendering (via progress callbacks) and more detailed workflow status display.
  * Added execution status inspection and “autoapproved” submissions for approval flows.
* **Improvements**
  * Chat waiting is indefinite by default; `--timeout`/`timeout` remains available for finite waits.
  * Improved approval handling to avoid duplicate submissions and handle stale snapshots more safely.
  * Sanitized, structured, and truncated tool/terminal output (including removal of control sequences).
* **Documentation**
  * Updated command and SDK examples to explain `ask` vs `autoapprove`, polling/timeout behavior, and wait semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->