### PR TITLE
feat: name-first /servers table and /server selection by name

### DIFF
--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -506,6 +506,7 @@ class InteractiveShell:
         table = Table(title="Skyportal servers", border_style="blue", header_style="bold cyan")
         table.add_column("ID", style="cyan", no_wrap=True)
         table.add_column("Name", style="bold")
+        table.add_column("Kind", no_wrap=True)
         table.add_column("Status")
         table.add_column("Environment")
         table.add_column("Resources")
@@ -517,6 +518,7 @@ class InteractiveShell:
             table.add_row(
                 str(server.get("id", "-")),
                 str(server.get("name") or server.get("hostname") or "Unnamed"),
+                str(server.get("target_kind") or "ssh"),
                 "[{}]{}[/{}]".format(status_style, status, status_style),
                 str(server.get("host_type") or server.get("location") or "Custom"),
                 "{} vCPU / {} GB RAM / {} GPU".format(

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -46,8 +46,8 @@ COMMANDS: Dict[str, CommandInfo] = {
     ),
     "/servers": CommandInfo("/servers", "List your Skyportal servers"),
     "/server": CommandInfo(
-        "/server <id> [id ...] | auto",
-        "Select one or more servers for agent execution",
+        "/server <name> [name ...] | auto",
+        "Select one or more servers by name for agent execution",
     ),
     "/clear": CommandInfo("/clear", "Clear the terminal"),
     "/about": CommandInfo("/about", "Show Skyportal CLI information"),
@@ -119,6 +119,7 @@ class InteractiveShell:
         self.last_sequence = 0
         self.selected_server_id: Optional[int] = None
         self.selected_server_ids: List[int] = []
+        self.selected_server_names: List[str] = []
         self.previous_chat_id: Optional[int] = self._load_previous_chat_id()
         self._token_prompt = token_prompt or self._default_token_prompt
         self.session = session or self._create_prompt_session()
@@ -243,11 +244,11 @@ class InteractiveShell:
         ]
         if self.chat_id is not None:
             fragments.append(("class:context", " chat#{}".format(self.chat_id)))
-        if len(self.selected_server_ids) > 1:
-            fragments.append((
-                "class:context",
-                " servers#{}".format(",".join(str(value) for value in self.selected_server_ids)),
-            ))
+        labels = self.selected_server_names or [str(value) for value in self.selected_server_ids]
+        if len(labels) > 1:
+            fragments.append(("class:context", " servers#{}".format(",".join(labels))))
+        elif labels:
+            fragments.append(("class:context", " server#{}".format(labels[0])))
         elif self.selected_server_id is not None:
             fragments.append(("class:context", " server#{}".format(self.selected_server_id)))
         fragments.append(("class:arrow", "  > "))
@@ -363,6 +364,7 @@ class InteractiveShell:
         self.last_sequence = 0
         self.selected_server_id = None
         self.selected_server_ids = []
+        self.selected_server_names = []
         self._forget_chat()
         self.console.print("[green]✓ Local Skyportal credentials removed.[/green]")
 
@@ -428,14 +430,13 @@ class InteractiveShell:
             "Chat",
             "#{}".format(self.chat_id) if self.chat_id is not None else "[dim]new chat[/dim]",
         )
+        labels = self.selected_server_names or [str(value) for value in self.selected_server_ids]
         rows.add_row(
             "Servers",
-            ", ".join(str(value) for value in self.selected_server_ids)
-            if self.selected_server_ids
-            else "[dim]automatic[/dim]",
+            ", ".join(labels) if labels else "[dim]automatic[/dim]",
         )
-        if len(self.selected_server_ids) > 1:
-            rows.add_row("Default", str(self.selected_server_id))
+        if len(labels) > 1:
+            rows.add_row("Default", labels[0])
         rows.add_row("Credentials", str(CredentialStore.get_path()))
         self._print_section("Session status", style="#3b82f6")
         self.console.print(rows)
@@ -504,9 +505,7 @@ class InteractiveShell:
             self.console.print("[yellow]No servers found.[/yellow]")
             return
         table = Table(title="Skyportal servers", border_style="blue", header_style="bold cyan")
-        table.add_column("ID", style="cyan", no_wrap=True)
         table.add_column("Name", style="bold")
-        table.add_column("Kind", no_wrap=True)
         table.add_column("Status")
         table.add_column("Environment")
         table.add_column("Resources")
@@ -516,9 +515,7 @@ class InteractiveShell:
                 "green" if status.lower() in ("connected", "running", "ready", "online") else "yellow"
             )
             table.add_row(
-                str(server.get("id", "-")),
                 str(server.get("name") or server.get("hostname") or "Unnamed"),
-                str(server.get("target_kind") or "ssh"),
                 "[{}]{}[/{}]".format(status_style, status, status_style),
                 str(server.get("host_type") or server.get("location") or "Custom"),
                 "{} vCPU / {} GB RAM / {} GPU".format(
@@ -527,13 +524,13 @@ class InteractiveShell:
             )
         self.console.print(table)
         self.console.print(
-            "[dim]Select one or more with /server <id> [id ...], "
+            "[dim]Select one or more with /server <name> [name ...], "
             "or reset with /server auto.[/dim]"
         )
 
     def _cmd_server(self, args: List[str]) -> None:
         if not args:
-            self.console.print("[yellow]Usage:[/yellow] /server <id> [id ...] | auto")
+            self.console.print("[yellow]Usage:[/yellow] /server <name> [name ...] | auto")
             return
         if len(args) == 1 and args[0].lower() == "auto":
             if self.chat_id is not None:
@@ -541,21 +538,27 @@ class InteractiveShell:
                     self.client.select_chat_servers(self.chat_id, [])
             self.selected_server_id = None
             self.selected_server_ids = []
+            self.selected_server_names = []
             self.console.print("[green]✓ Server selection set to automatic.[/green]")
             return
         if any(argument.lower() == "auto" for argument in args):
-            self.console.print("[yellow]Use 'auto' by itself, or provide server IDs.[/yellow]")
+            self.console.print("[yellow]Use 'auto' by itself, or provide server names.[/yellow]")
             return
         self._require_api_connection()
-        raw_ids = [part for argument in args for part in argument.split(",") if part]
-        try:
-            server_ids = list(dict.fromkeys(int(value) for value in raw_ids))
-        except ValueError:
-            self.console.print("[yellow]Server IDs must be numbers, or use 'auto'.[/yellow]")
-            return
-        if not server_ids or any(server_id < 1 for server_id in server_ids):
-            self.console.print("[yellow]Server IDs must be positive numbers.[/yellow]")
-            return
+        tokens = [part.strip() for argument in args for part in argument.split(",") if part.strip()]
+        with self.console.status("[cyan]Resolving servers…[/cyan]", spinner="dots"):
+            servers = self._items(self.client.servers())
+        resolved, unknown = self._resolve_server_tokens(tokens, servers)
+        if unknown:
+            raise PortalError(
+                "Server{} {} {} not found in your account. Run /servers to see available names.".format(
+                    "s" if len(unknown) > 1 else "",
+                    ", ".join(unknown),
+                    "were" if len(unknown) > 1 else "was",
+                )
+            )
+        server_ids = [server_id for server_id, _ in resolved]
+        names = [name for _, name in resolved]
         if self.chat_id is not None:
             if len(server_ids) == 1:
                 # Keep the one-host path compatible with older website
@@ -569,28 +572,53 @@ class InteractiveShell:
                         server_ids,
                         active_server_id=server_ids[0],
                     )
-        else:
-            servers = self._items(self.client.servers())
-            available_ids = {str(server.get("id")) for server in servers}
-            missing = [server_id for server_id in server_ids if str(server_id) not in available_ids]
-            if missing:
-                raise PortalError(
-                    "Server{} {} {} not found in your account".format(
-                        "s" if len(missing) > 1 else "",
-                        ", ".join(str(server_id) for server_id in missing),
-                        "were" if len(missing) > 1 else "was",
-                    )
-                )
         self.selected_server_ids = server_ids
         self.selected_server_id = server_ids[0]
-        if len(server_ids) == 1:
-            message = "Server {} selected.".format(server_ids[0])
+        self.selected_server_names = names
+        if len(names) == 1:
+            message = "Server {} selected.".format(names[0])
         else:
             message = "Servers {} selected; {} is the default.".format(
-                ", ".join(str(server_id) for server_id in server_ids),
-                server_ids[0],
+                ", ".join(names),
+                names[0],
             )
         self.console.print("[green]✓ {}[/green]".format(message))
+
+    @staticmethod
+    def _resolve_server_tokens(
+        tokens: List[str], servers: List[Dict[str, Any]]
+    ) -> Tuple[List[Tuple[int, str]], List[str]]:
+        """Resolve /server arguments to unique (id, name) pairs; names win over numeric ids."""
+        by_name: Dict[str, Tuple[int, str]] = {}
+        by_folded: Dict[str, Optional[Tuple[int, str]]] = {}
+        by_id: Dict[str, Tuple[int, str]] = {}
+        for server in servers:
+            raw_id = server.get("id")
+            if raw_id is None:
+                continue
+            try:
+                server_id = int(raw_id)
+            except (ValueError, TypeError):
+                continue
+            name = str(server.get("name") or server.get("hostname") or server_id)
+            entry = (server_id, name)
+            by_id[str(server_id)] = entry
+            by_name.setdefault(name, entry)
+            folded = name.casefold()
+            # None marks an ambiguous case-insensitive name; exact match still works.
+            by_folded[folded] = None if folded in by_folded else entry
+        resolved: List[Tuple[int, str]] = []
+        seen: set = set()
+        unknown: List[str] = []
+        for token in tokens:
+            entry = by_name.get(token) or by_folded.get(token.casefold()) or by_id.get(token)
+            if entry is None:
+                unknown.append(token)
+                continue
+            if entry[0] not in seen:
+                seen.add(entry[0])
+                resolved.append(entry)
+        return resolved, unknown
 
     def _cmd_clear(self, args: List[str]) -> None:
         self.console.clear()

--- a/tests/test_shell_multihost.py
+++ b/tests/test_shell_multihost.py
@@ -93,8 +93,8 @@ def test_multi_server_scope_is_sent_atomically_with_first_turn(shell):
     assert client.begin_calls == [
         ("compare every selected host", None, None, [7, 9], 7),
     ]
-    assert "Servers 7, 9 selected; 7 is the default" in console.file.getvalue()
-    assert "servers#7,9" in "".join(part[1] for part in instance._prompt_fragments())
+    assert "Servers gpu-7, gpu-9 selected; gpu-7 is the default" in console.file.getvalue()
+    assert "servers#gpu-7,gpu-9" in "".join(part[1] for part in instance._prompt_fragments())
 
 
 def test_multi_server_scope_updates_existing_chat(shell):
@@ -151,11 +151,22 @@ def test_new_chat_scope_rejects_unowned_server(shell):
     assert instance.selected_server_ids == []
 
 
-@pytest.mark.parametrize("arguments", [[], ["auto", "7"], ["bad"], ["0"]])
+@pytest.mark.parametrize("arguments", [[], ["auto", "7"]])
 def test_invalid_multi_server_syntax_does_not_change_scope(shell, arguments):
     instance, client, _console = shell
 
     instance._cmd_server(arguments)
+
+    assert instance.selected_server_ids == []
+    assert client.scope_calls == []
+
+
+@pytest.mark.parametrize("arguments", [["bad"], ["0"]])
+def test_unresolvable_server_raises_and_does_not_change_scope(shell, arguments):
+    instance, client, _console = shell
+
+    with pytest.raises(PortalError, match="not found"):
+        instance._cmd_server(arguments)
 
     assert instance.selected_server_ids == []
     assert client.scope_calls == []

--- a/tests/test_shell_servers.py
+++ b/tests/test_shell_servers.py
@@ -1,10 +1,19 @@
-"""/servers renders SSH hosts and kube clusters as uniform rows with a Kind column."""
+"""/servers is name-first: no internal id or kind columns, and /server selects by hostname."""
 
 from io import StringIO
 
+import pytest
 from rich.console import Console
 
+from skyportal.portal import PortalError
 from skyportal.shell import InteractiveShell
+
+PAYLOAD = [
+    {"id": "102", "name": "cluster-dev", "status": "connected", "host_type": "Staging",
+     "target_kind": "kubernetes", "vcpu": 16, "ram": 31, "gpus": 0},
+    {"id": "7", "name": "gpu-7", "status": "connected", "host_type": "Production",
+     "target_kind": "ssh", "vcpu": 32, "ram": 128, "gpus": 2},
+]
 
 
 class FakeClient:
@@ -12,6 +21,8 @@ class FakeClient:
 
     def __init__(self, payload):
         self._payload = payload
+        self.single_scope_calls = []
+        self.scope_calls = []
 
     def is_authenticated(self):
         return True
@@ -19,34 +30,100 @@ class FakeClient:
     def servers(self):
         return self._payload
 
+    def select_chat_server(self, chat_id, server_id):
+        self.single_scope_calls.append((chat_id, server_id))
 
-def _render(payload, tmp_path, monkeypatch):
+    def select_chat_servers(self, chat_id, server_ids, active_server_id=None):
+        self.scope_calls.append((chat_id, server_ids, active_server_id))
+
+
+@pytest.fixture
+def shell(tmp_path, monkeypatch):
     monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
     out = StringIO()
     console = Console(file=out, width=160, force_terminal=False)
-    shell = InteractiveShell(
+    client = FakeClient(PAYLOAD)
+    instance = InteractiveShell(
         console=console,
-        client_factory=lambda: FakeClient(payload),
+        client_factory=lambda: client,
         session=object(),
         token_prompt=lambda _prompt: "",
     )
-    shell._cmd_servers([])
-    return out.getvalue()
+    return instance, client, out
 
 
-def test_kube_and_ssh_rows_share_columns(tmp_path, monkeypatch):
-    text = _render([
-        {"id": 1, "name": "ssh-box", "status": "connected", "host_type": "Physical",
-         "target_kind": "ssh", "vcpu": 32, "ram": 128, "gpus": 2},
-        {"id": 2, "name": "cluster-prod", "status": "connected", "host_type": "Production",
-         "target_kind": "kubernetes", "vcpu": 128, "ram": 1024, "gpus": 8},
-    ], tmp_path, monkeypatch)
-    assert "Kind" in text
-    assert "kubernetes" in text
-    assert "128 vCPU / 1024 GB RAM / 8 GPU" in text
+def test_table_has_no_id_or_kind_columns(shell):
+    instance, _, out = shell
+    instance._cmd_servers([])
+    text = out.getvalue()
+    assert "Kind" not in text
+    assert "102" not in text
+    for expected in ("Name", "Status", "Environment", "Resources"):
+        assert expected in text
+    assert "cluster-dev" in text
+    assert "16 vCPU / 31 GB RAM / 0 GPU" in text
     assert "32 vCPU / 128 GB RAM / 2 GPU" in text
+    assert "/server <name>" in text
 
 
-def test_missing_target_kind_defaults_to_ssh(tmp_path, monkeypatch):
-    text = _render([{"id": 3, "name": "old-backend", "status": "connected"}], tmp_path, monkeypatch)
-    assert "ssh" in text
+def test_select_by_name(shell):
+    instance, _, out = shell
+    instance._cmd_server(["cluster-dev"])
+    assert instance.selected_server_ids == [102]
+    assert instance.selected_server_names == ["cluster-dev"]
+    assert "Server cluster-dev selected" in out.getvalue()
+
+
+def test_select_multiple_names_dedupes_and_keeps_order(shell):
+    instance, _, out = shell
+    instance._cmd_server(["gpu-7", "cluster-dev", "gpu-7"])
+    assert instance.selected_server_ids == [7, 102]
+    assert instance.selected_server_names == ["gpu-7", "cluster-dev"]
+    assert "gpu-7 is the default" in out.getvalue()
+
+
+def test_numeric_id_still_accepted(shell):
+    instance, _, _ = shell
+    instance._cmd_server(["7"])
+    assert instance.selected_server_ids == [7]
+    assert instance.selected_server_names == ["gpu-7"]
+
+
+def test_case_insensitive_unique_match(shell):
+    instance, _, _ = shell
+    instance._cmd_server(["Cluster-Dev"])
+    assert instance.selected_server_ids == [102]
+
+
+def test_unknown_name_errors_and_keeps_selection(shell):
+    instance, _, _ = shell
+    instance._cmd_server(["cluster-dev"])
+    with pytest.raises(PortalError, match="nope"):
+        instance._cmd_server(["nope"])
+    assert instance.selected_server_ids == [102]
+
+
+def test_chat_selection_sends_resolved_id(shell):
+    instance, client, _ = shell
+    instance.chat_id = 55
+    instance._cmd_server(["cluster-dev"])
+    assert client.single_scope_calls == [(55, 102)]
+
+
+def test_prompt_and_status_show_names(shell):
+    instance, _, out = shell
+    instance._cmd_server(["cluster-dev", "gpu-7"])
+    prompt_text = "".join(fragment for _, fragment in instance._prompt_fragments())
+    assert "servers#cluster-dev,gpu-7" in prompt_text
+    assert "102" not in prompt_text
+    instance._cmd_status([])
+    status_text = out.getvalue()
+    assert "cluster-dev, gpu-7" in status_text
+
+
+def test_auto_resets_names(shell):
+    instance, _, _ = shell
+    instance._cmd_server(["cluster-dev"])
+    instance._cmd_server(["auto"])
+    assert instance.selected_server_ids == []
+    assert instance.selected_server_names == []

--- a/tests/test_shell_servers.py
+++ b/tests/test_shell_servers.py
@@ -1,0 +1,52 @@
+"""/servers renders SSH hosts and kube clusters as uniform rows with a Kind column."""
+
+from io import StringIO
+
+from rich.console import Console
+
+from skyportal.shell import InteractiveShell
+
+
+class FakeClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def is_authenticated(self):
+        return True
+
+    def servers(self):
+        return self._payload
+
+
+def _render(payload, tmp_path, monkeypatch):
+    monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    out = StringIO()
+    console = Console(file=out, width=160, force_terminal=False)
+    shell = InteractiveShell(
+        console=console,
+        client_factory=lambda: FakeClient(payload),
+        session=object(),
+        token_prompt=lambda _prompt: "",
+    )
+    shell._cmd_servers([])
+    return out.getvalue()
+
+
+def test_kube_and_ssh_rows_share_columns(tmp_path, monkeypatch):
+    text = _render([
+        {"id": 1, "name": "ssh-box", "status": "connected", "host_type": "Physical",
+         "target_kind": "ssh", "vcpu": 32, "ram": 128, "gpus": 2},
+        {"id": 2, "name": "cluster-prod", "status": "connected", "host_type": "Production",
+         "target_kind": "kubernetes", "vcpu": 128, "ram": 1024, "gpus": 8},
+    ], tmp_path, monkeypatch)
+    assert "Kind" in text
+    assert "kubernetes" in text
+    assert "128 vCPU / 1024 GB RAM / 8 GPU" in text
+    assert "32 vCPU / 128 GB RAM / 2 GPU" in text
+
+
+def test_missing_target_kind_defaults_to_ssh(tmp_path, monkeypatch):
+    text = _render([{"id": 3, "name": "old-backend", "status": "connected"}], tmp_path, monkeypatch)
+    assert "ssh" in text


### PR DESCRIPTION
## Summary

Review feedback on the /servers listing: internal ids and target kind are backend metadata, so the shell frontend no longer shows them. The table leads with the server name, and /server accepts hostnames, so `/server cluster-dev` works instead of `/server 1`. Numeric ids still resolve as a fallback so existing habits and scripts keep working. The prompt line and /status show the selected names instead of ids.

The listing data comes from SkyportalAi/skyportal-website#3135, which keeps id and target_kind in the API for machine consumers.

## Screenshots

> Screenshot lives locally at `/home/henrique/gitdocs/skyportal-website/.playwright-mcp/pr-3135-v2/` (gitignored, not pushed). Drag the PNG into the slot below.

### 1) Name-first table and selection by name

The table shows Name, Status, Environment and Resources only, and `/server demo-cluster` resolves the hostname and confirms with the name.

**File:** `01-cli-servers-by-name.png`

⬇️ DRAG `01-cli-servers-by-name.png` HERE ⬇️

---

## Testing

- tests/test_shell_servers.py: table has no id or kind columns, selection by name, multi name dedupe with order kept, numeric id fallback, case insensitive unique match, unknown name raises and keeps scope, chat path sends the resolved id, prompt and /status show names, auto resets.
- tests/test_shell_multihost.py updated for name labels; unresolvable tokens raise and keep scope.
- Full suite: 399 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced server selection to accept server **names** (case-insensitive, supports comma-separated lists and `auto`).
  * Updated the `/servers` table to show **Name, Status, Environment, and Resources** only (no internal identifiers).
* **Bug Fixes**
  * Improved `/status` and shell prompt output to display selected **server names** instead of IDs.
* **Tests**
  * Added and updated tests covering name-based selection, rendering changes, error handling for unknown servers, and `auto` reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->