### PR TITLE
fix_broadcast_approval

### DIFF
--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -306,9 +306,17 @@ class SkyportalClient:
             json_body={"message": message},
         )
 
-    def chat_status(self, chat_id: int) -> Dict[str, Any]:
-        """Get current headless workflow status."""
-        return self._request("GET", "/api/v1/agent/chat/{}/status/".format(chat_id))
+    def chat_status(
+        self,
+        chat_id: int,
+        *,
+        after_sequence: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get workflow status, optionally with incremental messages."""
+        path = "/api/v1/agent/chat/{}/status/".format(chat_id)
+        if after_sequence is not None:
+            path += "?" + urlencode({"after_sequence": after_sequence})
+        return self._request("GET", path)
 
     def get_execution_status(self, chat_id: int) -> Dict[str, Any]:
         """Get detailed execution state for an explicit status inspection."""
@@ -412,11 +420,16 @@ class SkyportalClient:
         latest_sequence = after_sequence
         result_messages: List[Dict[str, Any]] = []
 
-        def fetch_new_messages(*, deliver_progress: bool) -> tuple[List[Dict[str, Any]], bool]:
+        def fetch_new_messages(
+            *,
+            deliver_progress: bool,
+            payload: Optional[Dict[str, Any]] = None,
+        ) -> tuple[List[Dict[str, Any]], bool]:
             """Fetch, order, and record messages strictly beyond the local cursor."""
             nonlocal deadline, latest_sequence
 
-            payload = self.chat_messages(chat_id, after_sequence=latest_sequence)
+            if not isinstance(payload, dict) or "messages" not in payload:
+                payload = self.chat_messages(chat_id, after_sequence=latest_sequence)
             raw_messages = payload.get("messages", []) if isinstance(payload, dict) else []
             sequenced: List[tuple[int, Dict[str, Any]]] = []
             for message in raw_messages if isinstance(raw_messages, list) else []:
@@ -462,7 +475,7 @@ class SkyportalClient:
                     )
                 )
 
-            state = self.chat_status(chat_id)
+            state = self.chat_status(chat_id, after_sequence=latest_sequence)
             if on_status is not None:
                 try:
                     on_status(state)
@@ -481,7 +494,11 @@ class SkyportalClient:
                 break
 
             while True:
-                batch, has_more = fetch_new_messages(deliver_progress=True)
+                batch, has_more = fetch_new_messages(
+                    deliver_progress=True,
+                    payload=state,
+                )
+                state = {}
                 if not has_more or not batch:
                     break
             time.sleep(poll_interval)
@@ -490,7 +507,7 @@ class SkyportalClient:
         # needs to act. One persisted-message fetch is useful context, but a
         # consistency-settlement delay would only make the prompt/error noisy.
         if status in _IMMEDIATE_CHAT_STATUSES:
-            fetch_new_messages(deliver_progress=False)
+            fetch_new_messages(deliver_progress=False, payload=state)
         else:
             # A terminal status write can win a short race with its final
             # persisted message. Settle that race with a small fixed budget
@@ -498,7 +515,11 @@ class SkyportalClient:
             settlement_delay = _TERMINAL_MESSAGE_SETTLEMENT_INITIAL_DELAY
             messages_seen_before_terminal = bool(result_messages)
             for attempt in range(_TERMINAL_MESSAGE_SETTLEMENT_ATTEMPTS):
-                batch, has_more = fetch_new_messages(deliver_progress=False)
+                batch, has_more = fetch_new_messages(
+                    deliver_progress=False,
+                    payload=state,
+                )
+                state = {}
                 if batch:
                     while has_more:
                         next_batch, has_more = fetch_new_messages(deliver_progress=False)

--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -390,16 +390,21 @@ class SkyportalClient:
         timeout: Optional[float] = None,
         poll_interval: float = 1,
         on_progress: Optional[Callable[[List[Dict[str, Any]]], None]] = None,
+        on_status: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> ChatTurnResult:
         """Poll a headless chat until it completes, pauses, or fails.
 
         While the workflow is busy, persisted messages are fetched alongside
         its lightweight status. ``on_progress`` receives each newly observed
-        message batch at most once. The returned result retains all observed
-        messages regardless of callback delivery, and ``latest_sequence``
-        covers that complete set so renderers can deduplicate by sequence. The
-        timeout is an idle deadline and is extended by a new message batch or
-        a real workflow-status transition. ``None`` disables that deadline.
+        message batch at most once, while ``on_status`` receives each current
+        workflow snapshot so interactive clients can display the active plan
+        step or command without exposing private model reasoning. Callback
+        failures never interrupt the remote turn. The returned result retains
+        all observed messages regardless of callback delivery, and
+        ``latest_sequence`` covers that complete set so renderers can
+        deduplicate by sequence. The timeout is an idle deadline and is
+        extended by a new message batch or a real workflow-status transition.
+        ``None`` disables that deadline.
         """
         deadline = time.monotonic() + timeout if timeout is not None else None
         state: Dict[str, Any] = {"status": "processing", "pending_approvals": []}
@@ -458,6 +463,11 @@ class SkyportalClient:
                 )
 
             state = self.chat_status(chat_id)
+            if on_status is not None:
+                try:
+                    on_status(state)
+                except Exception:
+                    pass
             status = str(state.get("status", "unknown"))
             if (
                 timeout is not None
@@ -579,6 +589,7 @@ class SkyportalClient:
         timeout: Optional[float] = None,
         poll_interval: float = 1,
         on_progress: Optional[Callable[[List[Dict[str, Any]]], None]] = None,
+        on_status: Optional[Callable[[Dict[str, Any]], None]] = None,
         *,
         server_ids: Optional[List[int]] = None,
         active_server_id: Optional[int] = None,
@@ -601,6 +612,7 @@ class SkyportalClient:
             timeout=timeout,
             poll_interval=poll_interval,
             on_progress=on_progress,
+            on_status=on_status,
         )
 
     @staticmethod

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -1100,15 +1100,13 @@ class InteractiveShell:
                 raise PortalError(
                     "Chat #{} returned an approval without an approval ID".format(turn.chat_id)
                 )
-            description = (
-                approval.get("executed_command")
-                or approval.get("command")
-                or approval.get("reason")
-                or json.dumps(approval, indent=2, sort_keys=True)
+            approval_type = str(approval.get("type", "") or "")
+            description = self._approval_description(
+                approval,
+                turn.messages,
             )
             self._print_section("Approval requested", style="yellow")
             self.console.print(Text(self._clean_terminal_text(description)))
-            approval_type = str(approval.get("type", "") or "")
             autoapprove = (
                 approval_type in _AUTOAPPROVE_TYPES
                 and self._permission_mode_for_approval() == "autoapprove"
@@ -1180,6 +1178,57 @@ class InteractiveShell:
             except KeyboardInterrupt:
                 self._cancel_active_turn(turn.chat_id)
                 return
+
+    @classmethod
+    def _approval_description(
+        cls,
+        approval: Dict[str, Any],
+        messages: List[Dict[str, Any]],
+    ) -> str:
+        """Describe one approval without repeating its canonical plan message."""
+        approval_type = str(approval.get("type", "") or "")
+        if approval_type == "plan":
+            approval_id = cls._approval_id_value(approval.get("approval_id"))
+            plan_already_rendered = any(
+                isinstance(message, dict)
+                and isinstance(message.get("metadata"), dict)
+                and message["metadata"].get("type") == "plan_approval_requested"
+                and (
+                    not approval_id
+                    or cls._approval_id_value(
+                        message["metadata"].get("approval_id")
+                    )
+                    == approval_id
+                )
+                for message in messages
+            )
+            if plan_already_rendered:
+                return "Approve the execution plan shown above to begin."
+
+            plan = approval.get("plan")
+            if isinstance(plan, dict):
+                title = str(plan.get("title") or "Execution plan")
+                steps = plan.get("steps")
+                lines = [title]
+                if isinstance(steps, list):
+                    for index, step in enumerate(steps, start=1):
+                        if not isinstance(step, dict):
+                            continue
+                        name = str(step.get("name") or f"Step {index}")
+                        description = str(step.get("description") or "")
+                        lines.append(
+                            f"{index}. {name}"
+                            + (f": {description}" if description else "")
+                        )
+                return "\n".join(lines)
+            return "Approve this execution plan to begin."
+
+        return str(
+            approval.get("executed_command")
+            or approval.get("command")
+            or approval.get("reason")
+            or json.dumps(approval, indent=2, sort_keys=True)
+        )
 
     def _render_assistant_messages(
         self,

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -853,13 +853,16 @@ class InteractiveShell:
         self.chat_id = chat_id
         render_state = self._new_render_state()
         try:
-            with self.console.status(self._THINKING_STATUS, spinner="dots12"):
+            with self.console.status(self._THINKING_STATUS, spinner="dots12") as status:
                 turn = self.client.wait_for_chat(
                     chat_id,
                     after_sequence=self.last_sequence,
                     timeout=None,
                     on_progress=lambda messages: self._render_incremental_messages(
                         messages, render_state
+                    ),
+                    on_status=lambda snapshot: status.update(
+                        self._live_status_line(snapshot)
                     ),
                 )
         except KeyboardInterrupt:
@@ -883,6 +886,16 @@ class InteractiveShell:
     @staticmethod
     def _new_render_state() -> Dict[str, Any]:
         return {"seen": set(), "rendered": False}
+
+    def _live_status_line(self, snapshot: Dict[str, Any]) -> Text:
+        """Build a safe live activity line from the server's public status."""
+        activity = snapshot.get("activity") if isinstance(snapshot, dict) else None
+        label = activity.get("label") if isinstance(activity, dict) else None
+        if not label:
+            label = "Skyportal is thinking…"
+        line = Text(self._bounded_one_line(label, 180), style="bold cyan")
+        line.append("  Ctrl-C to stop", style="dim")
+        return line
 
     def _render_incremental_messages(
         self,
@@ -1145,6 +1158,9 @@ class InteractiveShell:
                                 timeout=None,
                                 on_progress=lambda messages: self._render_incremental_messages(
                                     messages, render_state
+                                ),
+                                on_status=lambda snapshot: status.update(
+                                    self._live_status_line(snapshot)
                                 ),
                             )
                         break

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -560,6 +560,28 @@ def test_wait_for_chat_new_messages_extend_idle_deadline(credential_path):
     assert result.latest_sequence == 5
 
 
+def test_wait_for_chat_streams_public_status_snapshots(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    processing = {
+        "status": "processing",
+        "pending_approvals": [],
+        "activity": {"phase": "executing_plan", "label": "Working on plan step 2/13"},
+    }
+    idle = {
+        "status": "idle",
+        "pending_approvals": [],
+        "activity": {"phase": "idle", "label": "Idle"},
+    }
+    snapshots = []
+
+    with patch.object(client, "chat_status", side_effect=[processing, idle]), patch.object(
+        client, "chat_messages", return_value={"messages": [], "has_more": False}
+    ), patch("skyportal.portal.time.sleep"):
+        client.wait_for_chat(42, poll_interval=0, on_status=snapshots.append)
+
+    assert snapshots == [processing, idle]
+
+
 def test_wait_for_chat_duplicate_message_snapshot_does_not_extend_idle_deadline(
     credential_path,
 ):
@@ -679,6 +701,7 @@ def test_run_chat_turn_continues_existing_chat(credential_path):
         timeout=None,
         poll_interval=0,
         on_progress=None,
+        on_status=None,
     )
 
 
@@ -703,6 +726,7 @@ def test_run_chat_turn_forwards_progress_callback(credential_path):
         timeout=None,
         poll_interval=1,
         on_progress=progress_batches.append,
+        on_status=None,
     )
 
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -582,6 +582,47 @@ def test_wait_for_chat_streams_public_status_snapshots(credential_path):
     assert snapshots == [processing, idle]
 
 
+def test_wait_for_chat_uses_combined_status_message_payload(credential_path):
+    client = SkyportalClient("https://app.skyportal.ai")
+    thought = {
+        "sequence": 4,
+        "role": "assistant",
+        "content": "I’ll prepare the plan.",
+        "metadata": {"type": "react_thought"},
+    }
+    action = {
+        "sequence": 5,
+        "role": "assistant",
+        "content": "generate_plan(task=Deploy Kubernetes, steps=13 steps)",
+        "metadata": {"type": "react_action"},
+    }
+    plan = {
+        "sequence": 6,
+        "role": "assistant",
+        "content": "Deploy Kubernetes\n\n1. Check hosts",
+        "metadata": {
+            "type": "plan_approval_requested",
+            "approval_id": "a1",
+        },
+    }
+    combined = {
+        "status": "awaiting_approval",
+        "pending_approvals": [{"approval_id": "a1", "type": "plan"}],
+        "messages": [thought, action, plan],
+        "has_more": False,
+    }
+
+    with patch.object(client, "chat_status", return_value=combined) as get_status, patch.object(
+        client, "chat_messages"
+    ) as get_messages:
+        result = client.wait_for_chat(42, after_sequence=3, poll_interval=0)
+
+    get_status.assert_called_once_with(42, after_sequence=3)
+    get_messages.assert_not_called()
+    assert result.messages == [thought, action, plan]
+    assert result.pending_approvals == [{"approval_id": "a1", "type": "plan"}]
+
+
 def test_wait_for_chat_duplicate_message_snapshot_does_not_extend_idle_deadline(
     credential_path,
 ):

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -28,7 +28,9 @@ class FakeClient:
         self.begin_calls.append((message, chat_id, server_id))
         return chat_id if chat_id is not None else 100
 
-    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+    def wait_for_chat(
+        self, chat_id, after_sequence=0, timeout=300, on_progress=None, on_status=None
+    ):
         self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
         if self._wait_raises is not None:
             raise self._wait_raises

--- a/tests/test_shell_multihost.py
+++ b/tests/test_shell_multihost.py
@@ -67,7 +67,9 @@ class FakeClient:
         )
         return chat_id if chat_id is not None else 100
 
-    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+    def wait_for_chat(
+        self, chat_id, after_sequence=0, timeout=300, on_progress=None, on_status=None
+    ):
         self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
         if self.wait_results:
             return self.wait_results.pop(0)

--- a/tests/test_shell_permission.py
+++ b/tests/test_shell_permission.py
@@ -68,7 +68,9 @@ class PermissionClient:
             )
         return {"success": True}
 
-    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+    def wait_for_chat(
+        self, chat_id, after_sequence=0, timeout=300, on_progress=None, on_status=None
+    ):
         self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
         return next(self.wait_results)
 

--- a/tests/test_shell_streaming.py
+++ b/tests/test_shell_streaming.py
@@ -67,8 +67,15 @@ class StreamingClient:
     def begin_chat_turn(self, message, chat_id=None, server_id=None):
         return chat_id or 42
 
-    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+    def wait_for_chat(
+        self, chat_id, after_sequence=0, timeout=300, on_progress=None, on_status=None
+    ):
         self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
+        assert on_status is not None
+        on_status({
+            "status": "processing",
+            "activity": {"label": "Working on plan step 2/13: Install containerd"},
+        })
         first = _assistant("streamed first", 1)
         second = _tool("uptime", "up 10 days", 2)
         assert on_progress is not None
@@ -146,7 +153,9 @@ class ApprovalClient:
         self.status_calls.append(chat_id)
         return {"status": "processing", "pending_approvals": []}
 
-    def wait_for_chat(self, chat_id, after_sequence=0, timeout=300, on_progress=None):
+    def wait_for_chat(
+        self, chat_id, after_sequence=0, timeout=300, on_progress=None, on_status=None
+    ):
         self.wait_calls.append((chat_id, after_sequence, timeout, on_progress))
         if self.stale:
             approval = {"approval_id": "approval-1", "command": "uptime"}

--- a/tests/test_shell_tool_rendering.py
+++ b/tests/test_shell_tool_rendering.py
@@ -78,6 +78,26 @@ def _react_action_message(text="run_command(command=ls -la)", sequence=1):
     }
 
 
+def _plan_approval_message(approval_id="plan-approval-1", sequence=2):
+    return {
+        "role": "assistant",
+        "sequence": sequence,
+        "content": [{
+            "type": "text",
+            "text": (
+                "**Deploy Kubernetes**\n\n"
+                "**Steps:**\n"
+                "1. Check hosts: Inspect both servers\n"
+                "2. Install runtime: Install containerd"
+            ),
+        }],
+        "metadata": {
+            "type": "plan_approval_requested",
+            "approval_id": approval_id,
+        },
+    }
+
+
 def _console():
     return Console(file=StringIO(), force_terminal=False, width=200)
 
@@ -271,6 +291,60 @@ class TestAssistantMessageLine:
         assert "calling" in text
         assert "df -h" in text
         assert "Disk usage is at 50%." in text
+
+
+class TestPlanApprovalRendering:
+    def _shell(self):
+        console = _console()
+        shell = InteractiveShell(
+            console=console,
+            client_factory=lambda: object(),
+            session=object(),
+            token_prompt=lambda _prompt: "",
+        )
+        return shell, console
+
+    def test_canonical_plan_message_is_not_repeated_by_approval_prompt(self):
+        shell, console = self._shell()
+        message = _plan_approval_message()
+        approval = {
+            "approval_id": "plan-approval-1",
+            "type": "plan",
+            "plan": {
+                "title": "Deploy Kubernetes",
+                "steps": [
+                    {"name": "Check hosts", "description": "Inspect both servers"},
+                    {"name": "Install runtime", "description": "Install containerd"},
+                ],
+            },
+        }
+
+        shell._render_assistant_messages([message])
+        console.print(shell._approval_description(approval, [message]))
+
+        output = console.file.getvalue()
+        assert output.count("Inspect both servers") == 1
+        assert output.count("Install containerd") == 1
+        assert "Approve the execution plan shown above" in output
+        assert '"approval_id"' not in output
+
+    def test_plan_payload_is_rendered_once_when_message_has_not_arrived(self):
+        shell, _console = self._shell()
+        approval = {
+            "approval_id": "plan-approval-1",
+            "type": "plan",
+            "plan": {
+                "title": "Deploy Kubernetes",
+                "steps": [
+                    {"name": "Check hosts", "description": "Inspect both servers"},
+                ],
+            },
+        }
+
+        description = shell._approval_description(approval, [])
+
+        assert description.count("Inspect both servers") == 1
+        assert '"approval_id"' not in description
 
 
 class TestEmptyTurnMessage:


### PR DESCRIPTION
## Change type

Select **all** that apply and fill in the corresponding section(s) below.
Sections whose type is **not** checked may be left as-is.

- [ ] 🆕 New or changed CLI command / flag
- [ ] 🔄 Behavior change (observable difference for users)
- [ ] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

Describe the problem and the approach taken.

---

<!-- ✅ Required when "New or changed CLI command / flag" is checked -->
## CLI usage example

> **Required for new/changed commands or flags.**
> Show the command(s) as a user would type them, including representative
> options, and note which documentation page was updated.

```
# before (omit if this is a brand-new command)
skyportalai <old-command> [flags]

# after
skyportalai <new-command> [flags]
```

Docs updated: <!-- path(s) or "N/A – no public docs affected" -->

---

<!-- ✅ Required when "Behavior change" is checked -->
## Before / after

> **Required for behavior changes.**
> Describe what users experienced before and what they experience after.

**Before:** <!-- observable behavior or output -->

**After:** <!-- observable behavior or output -->

Test coverage: <!-- new/updated test file(s) or "covered by existing tests" -->

---

<!-- ✅ Required when "Security-sensitive change" is checked -->
## Security callout

> **Required for auth, credentials, kubeconfig, or secrets handling.**
> Explain the threat model impact of this change.

**What changed in security-sensitive code:**

**Why it is safe / how the risk is mitigated:**

**Credentials or secrets introduced:** None <!-- or describe and justify -->

---

<!-- ✅ Standard checklist – always complete this section -->
## Validation

- [ ] Tests added or updated where behavior changed
- [ ] `poetry run pytest` passes
- [ ] `poetry run ruff check .` passes
- [ ] Public API/configuration changes are documented
- [ ] No credentials or private run data are included

## Related issue

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live activity and workflow status updates during chat execution.
  * Interactive terminal displays now show richer “thinking” feedback and a “Ctrl-C to stop” hint.
  * Status updates continue safely even if a display callback encounters an error.

* **Bug Fixes**
  * Status feedback is also maintained while recovering from approval submissions.

* **Tests**
  * Added coverage for status updates and terminal display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->