### PR TITLE
ansible-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,33 @@ Remove the stored cluster credential when it is no longer needed:
 skyportalai kubernetes disconnect 17
 ```
 
+## Ansible playbooks
+
+Store validated playbooks in SkyPortal and reuse them across account-owned SSH
+targets. List responses omit YAML bodies; `show` retrieves one playbook when
+you need to inspect or edit it.
+
+```bash
+skyportalai ansible create bootstrap --file playbook.yml --description "Base host setup"
+skyportalai ansible list
+skyportalai ansible show 4
+skyportalai ansible update 4 --file playbook.yml
+```
+
+Deployments run through the ops agent and the normal command-approval policy.
+The playbook executes on the selected SSH host with a temporary, mode-restricted
+file that is removed after `ansible-playbook` exits.
+
+```bash
+skyportalai ansible deploy 4 --server 12
+skyportalai chat wait 91
+skyportalai chat approve 91 APPROVAL_ID --command "COMMAND_FROM_STATUS"
+skyportalai ansible delete 4 --yes
+```
+
+The Python SDK exposes the same lifecycle as `client.ansible.create(...)`,
+`.list()`, `.get(...)`, `.update(...)`, `.deploy(...)`, and `.delete(...)`.
+
 ## Observability agent
 
 Install the collector dependencies and review the deployment guide before

--- a/skyportalai/__init__.py
+++ b/skyportalai/__init__.py
@@ -11,6 +11,8 @@ from ._exceptions import (
 from ._version import __version__
 from .chat import Chat
 from .types import (
+    AnsibleDeployment,
+    AnsiblePlaybook,
     ApprovalResult,
     ChatStatus,
     KubernetesCluster,
@@ -26,6 +28,8 @@ __all__ = [
     "User",
     "Chat",
     "ChatStatus",
+    "AnsiblePlaybook",
+    "AnsibleDeployment",
     "KubernetesCluster",
     "PendingApproval",
     "PermissionMode",

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -16,6 +16,7 @@ from ._exceptions import (
     SkyportalError,
 )
 from ._version import __version__
+from .resources.ansible import AnsibleResource
 from .resources.chat import ChatResource
 from .resources.kubernetes import KubernetesResource
 from .resources.me import fetch_me
@@ -153,6 +154,7 @@ class Skyportal:
         self._backoff_base = 0.5
 
         self.chat = ChatResource(self)
+        self.ansible = AnsibleResource(self)
         self.kubernetes = KubernetesResource(self)
 
     def _request(self, method: str, path: str, *, params: dict | None = None,

--- a/skyportalai/cli/ansible.py
+++ b/skyportalai/cli/ansible.py
@@ -1,0 +1,193 @@
+"""Ansible playbook lifecycle commands for the public CLI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from .context import get_state as _state
+from .context import run_command
+
+ansible_app = typer.Typer(
+    help="Create, manage, list, and deploy Ansible playbooks through the ops agent."
+)
+
+_MAX_PLAYBOOK_BYTES = 256 * 1024
+
+
+def _read_playbook(path: str) -> str:
+    if path == "-":
+        raw = sys.stdin.buffer.read(_MAX_PLAYBOOK_BYTES + 1)
+        source = "stdin"
+    else:
+        resolved = Path(path).expanduser()
+        try:
+            with resolved.open("rb") as handle:
+                raw = handle.read(_MAX_PLAYBOOK_BYTES + 1)
+        except OSError as exc:
+            raise typer.BadParameter(f"Cannot read playbook {resolved}: {exc}") from None
+        source = str(resolved)
+    if len(raw) > _MAX_PLAYBOOK_BYTES:
+        raise typer.BadParameter("Playbook exceeds the 256 KiB safety limit.")
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise typer.BadParameter(f"Cannot decode playbook from {source}: {exc}") from None
+    if not content.strip():
+        raise typer.BadParameter(f"Playbook from {source} is empty.")
+    return content
+
+
+@ansible_app.command("create")
+def create(
+    context: typer.Context,
+    name: Annotated[str, typer.Argument(help="Display name for the playbook.")],
+    file: Annotated[
+        str,
+        typer.Option("--file", "-f", help="Playbook YAML path, or '-' for standard input."),
+    ],
+    description: Annotated[
+        str,
+        typer.Option("--description", "-d", help="Optional playbook description."),
+    ] = "",
+) -> None:
+    """Validate and store a new Ansible playbook."""
+    content = _read_playbook(file)
+    playbook = run_command(
+        context,
+        lambda state: state.client().ansible.create(
+            name,
+            content,
+            description=description,
+        ),
+    )
+    _state(context).output.success(
+        playbook,
+        human=f'Created Ansible playbook #{playbook.id}: {playbook.name}',
+    )
+
+
+@ansible_app.command("list")
+def list_playbooks(context: typer.Context) -> None:
+    """List stored Ansible playbooks."""
+    playbooks = run_command(context, lambda state: state.client().ansible.list())
+    if not playbooks:
+        human = "No Ansible playbooks stored."
+    else:
+        lines = ["ID  NAME  UPDATED  DESCRIPTION"]
+        for playbook in playbooks:
+            lines.append(
+                f"{playbook.id}  {playbook.name}  {playbook.updated_at or '-'}  "
+                f"{playbook.description or '-'}"
+            )
+        human = "\n".join(lines)
+    _state(context).output.success(playbooks, human=human)
+
+
+@ansible_app.command("show")
+def show(
+    context: typer.Context,
+    playbook_id: Annotated[int, typer.Argument(min=1, help="Playbook ID.")],
+) -> None:
+    """Show one playbook, including its YAML."""
+    playbook = run_command(
+        context,
+        lambda state: state.client().ansible.get(playbook_id),
+    )
+    _state(context).output.success(
+        playbook,
+        human=(
+            f"Ansible playbook #{playbook.id}: {playbook.name}\n"
+            f"{playbook.description}\n\n{playbook.content}"
+        ).rstrip(),
+    )
+
+
+@ansible_app.command("update")
+def update(
+    context: typer.Context,
+    playbook_id: Annotated[int, typer.Argument(min=1, help="Playbook ID.")],
+    name: Annotated[str | None, typer.Option("--name", help="New display name.")] = None,
+    file: Annotated[
+        str | None,
+        typer.Option("--file", "-f", help="Replacement YAML path, or '-' for standard input."),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option("--description", "-d", help="Replacement description."),
+    ] = None,
+) -> None:
+    """Update a playbook's name, description, YAML, or any combination."""
+    if name is None and file is None and description is None:
+        _state(context).output.failure("Provide --name, --file, --description, or a combination.")
+        raise typer.Exit(2)
+    content = _read_playbook(file) if file is not None else None
+    playbook = run_command(
+        context,
+        lambda state: state.client().ansible.update(
+            playbook_id,
+            name=name,
+            content=content,
+            description=description,
+        ),
+    )
+    _state(context).output.success(
+        playbook,
+        human=f'Updated Ansible playbook #{playbook.id}: {playbook.name}',
+    )
+
+
+@ansible_app.command("delete")
+def delete(
+    context: typer.Context,
+    playbook_id: Annotated[int, typer.Argument(min=1, help="Playbook ID.")],
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+) -> None:
+    """Delete a stored Ansible playbook."""
+    if not yes:
+        if _state(context).output.json_mode:
+            _state(context).output.failure("--yes is required when using --json mode")
+            raise typer.Exit(1)
+        if not typer.confirm(f"Delete Ansible playbook #{playbook_id}?"):
+            raise typer.Abort()
+    result = run_command(
+        context,
+        lambda state: state.client().ansible.delete(playbook_id),
+    )
+    _state(context).output.success(
+        result,
+        human=f"Deleted Ansible playbook #{playbook_id}.",
+    )
+
+
+@ansible_app.command("deploy")
+def deploy(
+    context: typer.Context,
+    playbook_id: Annotated[int, typer.Argument(min=1, help="Playbook ID.")],
+    server_id: Annotated[
+        int,
+        typer.Option("--server", "-s", min=1, help="Owned SSH target ID."),
+    ],
+) -> None:
+    """Start an audited agent deployment of a stored playbook."""
+    deployment = run_command(
+        context,
+        lambda state: state.client().ansible.deploy(
+            playbook_id,
+            server_id=server_id,
+        ),
+    )
+    _state(context).output.success(
+        deployment,
+        human=(
+            f"Ansible deployment started in chat #{deployment.chat_id} "
+            f"(playbook #{deployment.playbook_id} → server #{deployment.server_id}).\n"
+            f"Monitor it with: skyportalai chat wait {deployment.chat_id}"
+        ),
+    )

--- a/skyportalai/cli/main.py
+++ b/skyportalai/cli/main.py
@@ -104,10 +104,12 @@ def set_config(
     )
 
 
+from .ansible import ansible_app  # noqa: E402
 from .chat import chat_app  # noqa: E402
 from .kubernetes import kubernetes_app  # noqa: E402
 
 app.add_typer(chat_app, name="chat")
+app.add_typer(ansible_app, name="ansible")
 app.add_typer(kubernetes_app, name="kubernetes")
 
 

--- a/skyportalai/resources/ansible.py
+++ b/skyportalai/resources/ansible.py
@@ -1,0 +1,108 @@
+"""Ansible playbook lifecycle and deployment resource."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..types import AnsibleDeployment, AnsiblePlaybook
+
+if TYPE_CHECKING:
+    from .._client import Skyportal
+
+
+def _positive_id(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+class AnsibleResource:
+    """Create, manage, list, and deploy account-owned Ansible playbooks."""
+
+    def __init__(self, client: "Skyportal"):
+        self._client = client
+
+    def list(self) -> list[AnsiblePlaybook]:
+        data = self._client._request("GET", "/api/v1/infrastructure/ansible/")
+        return [
+            AnsiblePlaybook.from_dict(item)
+            for item in data.get("playbooks") or []
+            if isinstance(item, dict)
+        ]
+
+    def get(self, playbook_id: int) -> AnsiblePlaybook:
+        playbook_id = _positive_id(playbook_id, "playbook_id")
+        data = self._client._request(
+            "GET",
+            f"/api/v1/infrastructure/ansible/{playbook_id}/",
+        )
+        return AnsiblePlaybook.from_dict(data.get("playbook") or {})
+
+    def create(
+        self,
+        name: str,
+        content: str,
+        *,
+        description: str = "",
+    ) -> AnsiblePlaybook:
+        name = name.strip()
+        if not name:
+            raise ValueError("name cannot be empty")
+        if not content.strip():
+            raise ValueError("content cannot be empty")
+        data = self._client._request(
+            "POST",
+            "/api/v1/infrastructure/ansible/",
+            json={
+                "name": name,
+                "description": description.strip(),
+                "content": content,
+            },
+        )
+        return AnsiblePlaybook.from_dict(data.get("playbook") or {})
+
+    def update(
+        self,
+        playbook_id: int,
+        *,
+        name: str | None = None,
+        content: str | None = None,
+        description: str | None = None,
+    ) -> AnsiblePlaybook:
+        playbook_id = _positive_id(playbook_id, "playbook_id")
+        body = {}
+        if name is not None:
+            if not name.strip():
+                raise ValueError("name cannot be empty")
+            body["name"] = name.strip()
+        if content is not None:
+            if not content.strip():
+                raise ValueError("content cannot be empty")
+            body["content"] = content
+        if description is not None:
+            body["description"] = description.strip()
+        if not body:
+            raise ValueError("provide name, content, description, or a combination")
+        data = self._client._request(
+            "PATCH",
+            f"/api/v1/infrastructure/ansible/{playbook_id}/",
+            json=body,
+        )
+        return AnsiblePlaybook.from_dict(data.get("playbook") or {})
+
+    def delete(self, playbook_id: int) -> dict:
+        playbook_id = _positive_id(playbook_id, "playbook_id")
+        return self._client._request(
+            "DELETE",
+            f"/api/v1/infrastructure/ansible/{playbook_id}/",
+        )
+
+    def deploy(self, playbook_id: int, *, server_id: int) -> AnsibleDeployment:
+        playbook_id = _positive_id(playbook_id, "playbook_id")
+        server_id = _positive_id(server_id, "server_id")
+        data = self._client._request(
+            "POST",
+            f"/api/v1/infrastructure/ansible/{playbook_id}/deploy/",
+            json={"server_id": server_id},
+        )
+        return AnsibleDeployment.from_dict(data)

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -56,6 +56,54 @@ class KubernetesCluster:
 
 
 @dataclass(frozen=True)
+class AnsiblePlaybook:
+    """An account-owned Ansible playbook."""
+
+    id: int
+    name: str
+    description: str = ""
+    content: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+    raw: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AnsiblePlaybook":
+        return cls(
+            id=int(data.get("id", 0) or 0),
+            name=str(data.get("name") or ""),
+            description=str(data.get("description") or ""),
+            content=str(data.get("content") or ""),
+            created_at=str(data.get("created_at") or ""),
+            updated_at=str(data.get("updated_at") or ""),
+            raw=dict(data),
+        )
+
+
+@dataclass(frozen=True)
+class AnsibleDeployment:
+    """An asynchronous agent deployment started for an Ansible playbook."""
+
+    chat_id: int
+    playbook_id: int
+    server_id: int
+    status: str = "processing"
+    poll_url: str = ""
+    raw: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AnsibleDeployment":
+        return cls(
+            chat_id=int(data.get("chat_id", 0) or 0),
+            playbook_id=int(data.get("playbook_id", 0) or 0),
+            server_id=int(data.get("server_id", 0) or 0),
+            status=str(data.get("status") or ""),
+            poll_url=str(data.get("poll_url") or ""),
+            raw=dict(data),
+        )
+
+
+@dataclass(frozen=True)
 class PendingApproval:
     """An approval the agent is blocked on (bash command or plan)."""
 

--- a/tests/test_ansible.py
+++ b/tests/test_ansible.py
@@ -1,0 +1,70 @@
+import pytest
+
+from skyportalai import AnsibleDeployment, AnsiblePlaybook
+from skyportalai._client import Skyportal
+
+
+def _client():
+    return Skyportal(api_key="sk-test", base_url="https://api.test")
+
+
+def test_create_list_get_update_delete_and_deploy(requests_mock):
+    base = "https://api.test/api/v1/infrastructure/ansible"
+    playbook_payload = {
+        "id": 4,
+        "name": "bootstrap",
+        "description": "Base packages",
+        "content": "- hosts: all\n  tasks: []\n",
+        "updated_at": "2026-07-24T12:00:00+00:00",
+    }
+    requests_mock.post(f"{base}/", json={"playbook": playbook_payload}, status_code=201)
+    requests_mock.get(
+        f"{base}/",
+        json={"playbooks": [{key: value for key, value in playbook_payload.items() if key != "content"}]},
+    )
+    requests_mock.get(f"{base}/4/", json={"playbook": playbook_payload})
+    requests_mock.patch(
+        f"{base}/4/",
+        json={"playbook": {**playbook_payload, "description": "Updated"}},
+    )
+    requests_mock.delete(f"{base}/4/", json={"success": True, "playbook_id": 4})
+    requests_mock.post(
+        f"{base}/4/deploy/",
+        json={
+            "chat_id": 91,
+            "playbook_id": 4,
+            "server_id": 12,
+            "status": "processing",
+            "poll_url": "/api/v1/agent/chat/91/status/",
+        },
+        status_code=202,
+    )
+
+    resource = _client().ansible
+    created = resource.create(
+        "bootstrap",
+        "- hosts: all\n  tasks: []",
+        description="Base packages",
+    )
+    assert isinstance(created, AnsiblePlaybook)
+    assert resource.list()[0].content == ""
+    assert resource.get(4).content.startswith("- hosts")
+    assert resource.update(4, description="Updated").description == "Updated"
+    assert resource.delete(4)["success"] is True
+    deployment = resource.deploy(4, server_id=12)
+    assert isinstance(deployment, AnsibleDeployment)
+    assert deployment.chat_id == 91
+
+
+def test_lifecycle_validation_happens_before_network():
+    resource = _client().ansible
+    with pytest.raises(ValueError):
+        resource.create("", "- hosts: all")
+    with pytest.raises(ValueError):
+        resource.create("name", "")
+    with pytest.raises(ValueError):
+        resource.get(True)
+    with pytest.raises(ValueError):
+        resource.update(1)
+    with pytest.raises(ValueError):
+        resource.deploy(1, server_id=0)

--- a/tests/test_cli_ansible.py
+++ b/tests/test_cli_ansible.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from skyportalai.cli.context import CLIContext
+from skyportalai.cli.main import app
+from skyportalai.types import AnsibleDeployment, AnsiblePlaybook
+
+runner = CliRunner()
+
+
+class FakeAnsibleResource:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, name, content, *, description):
+        self.calls.append(("create", name, content, description))
+        return AnsiblePlaybook(id=5, name=name, content=content, description=description)
+
+    def list(self):
+        self.calls.append(("list",))
+        return [AnsiblePlaybook(id=5, name="bootstrap", updated_at="today")]
+
+    def get(self, playbook_id):
+        self.calls.append(("get", playbook_id))
+        return AnsiblePlaybook(id=playbook_id, name="bootstrap", content="- hosts: all\n")
+
+    def update(self, playbook_id, **changes):
+        self.calls.append(("update", playbook_id, changes))
+        return AnsiblePlaybook(id=playbook_id, name=changes.get("name") or "bootstrap")
+
+    def delete(self, playbook_id):
+        self.calls.append(("delete", playbook_id))
+        return {"success": True, "playbook_id": playbook_id}
+
+    def deploy(self, playbook_id, *, server_id):
+        self.calls.append(("deploy", playbook_id, server_id))
+        return AnsibleDeployment(chat_id=31, playbook_id=playbook_id, server_id=server_id)
+
+
+def _fake_client(monkeypatch, tmp_path):
+    monkeypatch.setenv("SKYPORTAL_CONFIG_PATH", str(tmp_path / "config.yaml"))
+    monkeypatch.setenv("SKYPORTAL_CREDENTIALS_PATH", str(tmp_path / "credentials.json"))
+    monkeypatch.setenv("SKYPORTAL_API_KEY", "sk-test")
+    resource = FakeAnsibleResource()
+    monkeypatch.setattr(
+        CLIContext,
+        "client",
+        lambda self: SimpleNamespace(ansible=resource),
+    )
+    return resource
+
+
+def test_create_reads_file_and_lifecycle_commands(monkeypatch, tmp_path):
+    resource = _fake_client(monkeypatch, tmp_path)
+    playbook = tmp_path / "playbook.yml"
+    playbook.write_text("- hosts: all\n  tasks: []\n")
+
+    created = runner.invoke(
+        app,
+        ["--json", "ansible", "create", "bootstrap", "-f", str(playbook)],
+    )
+    listed = runner.invoke(app, ["--json", "ansible", "list"])
+    shown = runner.invoke(app, ["--json", "ansible", "show", "5"])
+    updated = runner.invoke(
+        app,
+        ["--json", "ansible", "update", "5", "--name", "base"],
+    )
+    deleted = runner.invoke(app, ["--json", "ansible", "delete", "5", "--yes"])
+    deployed = runner.invoke(
+        app,
+        ["--json", "ansible", "deploy", "5", "--server", "12"],
+    )
+
+    for result in (created, listed, shown, updated, deleted, deployed):
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["ok"] is True
+    assert [call[0] for call in resource.calls] == [
+        "create", "list", "get", "update", "delete", "deploy",
+    ]
+
+
+def test_update_requires_a_change(monkeypatch, tmp_path):
+    _fake_client(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["--json", "ansible", "update", "5"])
+    assert result.exit_code == 2
+    assert json.loads(result.output)["ok"] is False

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -8,6 +8,8 @@ def test_public_exports_present():
         "User",
         "Chat",
         "ChatStatus",
+        "AnsiblePlaybook",
+        "AnsibleDeployment",
         "KubernetesCluster",
         "PendingApproval",
         "ApprovalResult",


### PR DESCRIPTION
## Change type

Select **all** that apply and fill in the corresponding section(s) below.
Sections whose type is **not** checked may be left as-is.

- [ ] 🆕 New or changed CLI command / flag
- [ ] 🔄 Behavior change (observable difference for users)
- [ ] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

Describe the problem and the approach taken.

---

<!-- ✅ Required when "New or changed CLI command / flag" is checked -->
## CLI usage example

> **Required for new/changed commands or flags.**
> Show the command(s) as a user would type them, including representative
> options, and note which documentation page was updated.

```
# before (omit if this is a brand-new command)
skyportalai <old-command> [flags]

# after
skyportalai <new-command> [flags]
```

Docs updated: <!-- path(s) or "N/A – no public docs affected" -->

---

<!-- ✅ Required when "Behavior change" is checked -->
## Before / after

> **Required for behavior changes.**
> Describe what users experienced before and what they experience after.

**Before:** <!-- observable behavior or output -->

**After:** <!-- observable behavior or output -->

Test coverage: <!-- new/updated test file(s) or "covered by existing tests" -->

---

<!-- ✅ Required when "Security-sensitive change" is checked -->
## Security callout

> **Required for auth, credentials, kubeconfig, or secrets handling.**
> Explain the threat model impact of this change.

**What changed in security-sensitive code:**

**Why it is safe / how the risk is mitigated:**

**Credentials or secrets introduced:** None <!-- or describe and justify -->

---

<!-- ✅ Standard checklist – always complete this section -->
## Validation

- [ ] Tests added or updated where behavior changed
- [ ] `poetry run pytest` passes
- [ ] `poetry run ruff check .` passes
- [ ] Public API/configuration changes are documented
- [ ] No credentials or private run data are included

## Related issue

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ansible playbook management through the CLI and Python SDK.
  * Create, list, view, update, delete, and deploy playbooks to selected SSH hosts.
  * Added support for YAML files and standard command approval during deployments.
  * Added public playbook and deployment result types.

* **Documentation**
  * Added usage instructions and command examples for Ansible workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->