### PR TITLE
feat(shell): surface the upgrade prompt when the monthly rate limit is hit

### DIFF
--- a/skyportal/portal.py
+++ b/skyportal/portal.py
@@ -169,6 +169,10 @@ class SkyportalClient:
         """Return the account API-key page used by the CLI."""
         return "{}/keys/?{}".format(self.base_url, urlencode({"source": "cli"}))
 
+    def billing_url(self) -> str:
+        """Return the billing/upgrade page the web chat's quota modal links to."""
+        return "{}/billing/?{}".format(self.base_url, urlencode({"upgrade": "true"}))
+
     def set_access_token(self, access_token: str, validate: bool = True) -> None:
         """Validate and persist an API key or short-lived access token."""
         token = access_token.strip()

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -17,11 +17,18 @@ from prompt_toolkit.shortcuts import prompt as secure_prompt
 from prompt_toolkit.styles import Style
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 
-from skyportal.portal import ChatTurnResult, CredentialStore, PortalError, SkyportalClient
+from skyportal.portal import (
+    PRODUCTION_APP_URL,
+    ChatTurnResult,
+    CredentialStore,
+    PortalError,
+    SkyportalClient,
+)
 
 _PERMISSION_MODES = frozenset({"ask", "autoapprove"})
 _AUTOAPPROVE_TYPES = frozenset({"", "bash_command", "plan"})
@@ -1303,10 +1310,15 @@ class InteractiveShell:
         which lines were the agent's actual response versus its own internal
         narration of what it was about to do."""
         text = self._message_text(message)
-        if not text:
-            return None
         metadata = message.get("metadata", {})
         msg_type = metadata.get("type") if isinstance(metadata, dict) else None
+        if msg_type == "prompt_limit_reached":
+            # Keyed on metadata alone: the structured quota payload can stand
+            # in for an empty content string, and an empty content string must
+            # not hide the one message that explains why the turn was refused.
+            return self._prompt_limit_notice(text, metadata)
+        if not text:
+            return None
         if msg_type == "react_thought":
             line = Text("· ", style="dim italic")
             line.append(self._clean_terminal_text(text), style="dim italic")
@@ -1316,6 +1328,58 @@ class InteractiveShell:
             line.append(self._clean_terminal_text(text), style="bold")
             return line
         return Markdown(self._clean_terminal_text(text))
+
+    def _prompt_limit_notice(self, text: str, metadata: Dict[str, Any]) -> Panel:
+        """Panel for the quota notice a rate-limited turn persists (metadata
+        type prompt_limit_reached, quota/upgrade_suggestion payloads — see
+        agent_service.py's rate-limit branch server-side). The web chat shows
+        the same numbers in a blocking modal with a /billing/ CTA; the
+        terminal equivalent renders usage from the structured payload (the
+        content string is only a fallback) and always ends with the billing
+        URL so hitting the limit is never a dead end."""
+        quota = metadata.get("quota")
+        tier_used = quota.get("tier_used") if isinstance(quota, dict) else None
+        tier_limit = quota.get("tier_limit") if isinstance(quota, dict) else None
+        body = Text()
+        if tier_used is not None and tier_limit is not None:
+            body.append(
+                "You've used {} of {} prompts this month.".format(
+                    self._bounded_one_line(tier_used, 40),
+                    self._bounded_one_line(tier_limit, 40),
+                )
+            )
+        elif text:
+            body.append(self._bounded_multiline(text))
+        suggestion = metadata.get("upgrade_suggestion")
+        suggestion_text = (
+            self._bounded_one_line(suggestion.get("message"), 300)
+            if isinstance(suggestion, dict) and suggestion.get("message")
+            else ""
+        )
+        if suggestion_text and suggestion_text not in body.plain:
+            if body.plain:
+                body.append("\n")
+            body.append(suggestion_text)
+        if body.plain:
+            body.append("\n")
+        body.append("→ Upgrade or buy more prompts: ", style="bold")
+        body.append(self._billing_upgrade_url(), style="bold #3b82f6")
+        return Panel(
+            body,
+            border_style="red",
+            title="Prompt limit reached",
+            title_align="left",
+            expand=False,
+        )
+
+    def _billing_upgrade_url(self) -> str:
+        """The client owns URL derivation so custom deployments point at
+        their own billing page; fall back to production when the shell was
+        built around a client stub without billing_url()."""
+        billing_url = getattr(self.client, "billing_url", None)
+        if callable(billing_url):
+            return str(billing_url())
+        return "{}/billing/?upgrade=true".format(PRODUCTION_APP_URL)
 
     @staticmethod
     def _tool_result_line(message: Dict[str, Any]) -> Optional[Text]:
@@ -1381,10 +1445,18 @@ class InteractiveShell:
                     printable.append(("user", text, None))
             elif role == "assistant":
                 text = self._message_text(m)
-                if not text:
-                    continue
                 metadata = m.get("metadata", {})
                 msg_type = metadata.get("type") if isinstance(metadata, dict) else None
+                if msg_type == "prompt_limit_reached":
+                    # Replays with the full panel (already a renderable, not
+                    # prose) — and, like the live path, an empty content
+                    # string must not drop the notice from the replay.
+                    printable.append(
+                        ("assistant", self._prompt_limit_notice(text, metadata), msg_type)
+                    )
+                    continue
+                if not text:
+                    continue
                 printable.append(("assistant", text, msg_type))
         if not printable:
             self.console.print("[dim]This chat has no earlier messages yet.[/dim]")
@@ -1404,6 +1476,8 @@ class InteractiveShell:
                 line = Text("→ calling ", style="dim")
                 line.append(self._clean_terminal_text(text), style="bold")
                 self.console.print(line)
+            elif msg_type == "prompt_limit_reached":
+                self.console.print(text)
             else:
                 self.console.print("[bold #3b82f6]agent[/bold #3b82f6]")
                 self.console.print(Markdown(self._clean_terminal_text(text)))

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1078,3 +1078,15 @@ def test_set_permission_mode_puts_only_supported_mode(credential_path):
         with pytest.raises(PortalError, match="ask.*autoapprove"):
             client.set_permission_mode("everything")
     invalid_call.assert_not_called()
+
+
+def test_billing_url_targets_the_billing_upgrade_page(credential_path):
+    client = SkyportalClient("https://skyportal.example/")
+
+    assert client.billing_url() == "https://skyportal.example/billing/?upgrade=true"
+
+
+def test_billing_url_on_the_marketing_host_normalizes_to_app(credential_path):
+    client = SkyportalClient("https://skyportal.ai/")
+
+    assert client.billing_url() == "https://app.skyportal.ai/billing/?upgrade=true"

--- a/tests/test_shell_prompt_limit.py
+++ b/tests/test_shell_prompt_limit.py
@@ -1,0 +1,137 @@
+"""Tests for the CLI's explicit prompt-limit branch (skyportal-website#3120).
+
+When a turn is rejected for quota, the backend persists an assistant message
+whose metadata carries type=prompt_limit_reached plus the quota payload and
+upgrade suggestion (skyportal-website#3119). Before this, that notice rendered
+through the generic Markdown prose path — no usage numbers and no way to act
+on it from the terminal."""
+
+from io import StringIO
+
+from rich.console import Console
+
+from skyportal.portal import ChatTurnResult, SkyportalClient
+from skyportal.shell import InteractiveShell
+
+_NOTICE_TEXT = (
+    "Monthly prompt limit reached (150 prompts). Upgrade to Pro for more prompts/month."
+)
+_UPGRADE = {"type": "upgrade_to_pro", "message": "Upgrade to Pro for more prompts/month."}
+
+
+def _prompt_limit_message(*, text=_NOTICE_TEXT, quota=..., upgrade_suggestion=..., sequence=0):
+    """Mirror the message agent_service.py persists on a rate-limited turn:
+    metadata always carries the quota dict and an upgrade_suggestion key
+    (None when the backend has no suggestion)."""
+    metadata = {"type": "prompt_limit_reached"}
+    if quota is ...:
+        quota = {"tier_used": 150, "tier_limit": 150, "purchased_remaining": 0}
+    if quota is not None:
+        metadata["quota"] = quota
+    metadata["upgrade_suggestion"] = dict(_UPGRADE) if upgrade_suggestion is ... else upgrade_suggestion
+    return {
+        "role": "assistant",
+        "sequence": sequence,
+        "content": [{"type": "text", "text": text}] if text else [],
+        "metadata": metadata,
+    }
+
+
+def _shell(client=None):
+    console = Console(file=StringIO(), force_terminal=False, width=200)
+    shell = InteractiveShell(
+        console=console,
+        client_factory=lambda: client if client is not None else object(),
+        session=object(),
+        token_prompt=lambda _prompt: "",
+    )
+    return shell, console
+
+
+def _render(message, client=None):
+    shell, console = _shell(client)
+    rendered = shell._render_assistant_messages([message])
+    return rendered, console.file.getvalue()
+
+
+class TestPromptLimitNotice:
+    def test_usage_is_rendered_from_quota_payload(self):
+        rendered, out = _render(_prompt_limit_message())
+
+        assert rendered is True
+        assert "Prompt limit reached" in out
+        assert "You've used 150 of 150 prompts this month." in out
+
+    def test_upgrade_suggestion_is_rendered_from_metadata(self):
+        """The suggestion must come from the metadata payload, not rely on
+        the backend having embedded it in the notice's content string."""
+        _, out = _render(
+            _prompt_limit_message(text="Monthly prompt limit reached (150 prompts).")
+        )
+
+        assert "Upgrade to Pro for more prompts/month." in out
+
+    def test_action_url_is_present_without_an_upgrade_suggestion(self):
+        """The notice must never be a dead end (#3120) — even with no
+        suggestion from the backend, point at the billing page."""
+        _, out = _render(_prompt_limit_message(upgrade_suggestion=None))
+
+        assert "https://app.skyportal.ai/billing/?upgrade=true" in out
+
+    def test_action_url_follows_a_custom_deployment_base_url(self):
+        client = SkyportalClient("https://skyportal.example/")
+
+        _, out = _render(_prompt_limit_message(), client=client)
+
+        assert "https://skyportal.example/billing/?upgrade=true" in out
+
+    def test_action_url_falls_back_to_production_without_client_support(self):
+        """Shell tests (and defensive paths) build the shell around a bare
+        object with no billing_url(); the notice still links somewhere real."""
+        _, out = _render(_prompt_limit_message())
+
+        assert "https://app.skyportal.ai/billing/?upgrade=true" in out
+
+    def test_missing_quota_payload_falls_back_to_notice_text(self):
+        rendered, out = _render(_prompt_limit_message(quota=None))
+
+        assert rendered is True
+        assert "Monthly prompt limit reached (150 prompts)." in out
+        assert "You've used" not in out
+        # Still not a dead end even when the quota payload is malformed.
+        assert "https://app.skyportal.ai/billing/?upgrade=true" in out
+
+    def test_renders_from_metadata_when_content_is_empty(self):
+        """The branch must fire on metadata type alone — an empty content
+        string must not fall into the generic 'nothing to render' path."""
+        rendered, out = _render(_prompt_limit_message(text=""))
+
+        assert rendered is True
+        assert "You've used 150 of 150 prompts this month." in out
+        assert "https://app.skyportal.ai/billing/?upgrade=true" in out
+
+    def test_history_replay_renders_the_quota_notice(self):
+        shell, console = _shell()
+
+        shell._render_history([_prompt_limit_message()])
+        out = console.file.getvalue()
+
+        assert "You've used 150 of 150 prompts this month." in out
+        assert "https://app.skyportal.ai/billing/?upgrade=true" in out
+
+
+def test_rate_limited_turn_shows_the_notice_not_the_fallback(tmp_path, monkeypatch):
+    """End to end through _process_turn (#3120's headline requirement): a
+    rate-limited turn ends with the pre-turn status and, before this branch,
+    an empty-content notice fell into the misleading 'finished with no
+    messages to show — check for a typo' fallback."""
+    monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    shell, console = _shell()
+    turn = ChatTurnResult(42, "idle", [_prompt_limit_message(text="")], [], 1)
+
+    shell._process_turn(turn)
+    out = console.file.getvalue()
+
+    assert "You've used 150 of 150 prompts this month." in out
+    assert "https://app.skyportal.ai/billing/?upgrade=true" in out
+    assert "no messages to show" not in out


### PR DESCRIPTION
Fixes SkyportalAi/skyportal-website#3120

## What

When the backend rejects a turn for quota, it persists an assistant message whose metadata carries `type: prompt_limit_reached` plus the `quota` and `upgrade_suggestion` payloads (SkyportalAi/skyportal-website#3145). The shell previously rendered that notice through the generic Markdown prose path, with no usage numbers and nothing to act on.

`_assistant_message_line()` now branches on that metadata type and renders a distinct panel:

* usage from the structured payload: `You've used {tier_used} of {tier_limit} prompts this month.`
* the `upgrade_suggestion` message when present (`Upgrade to Pro for more prompts/month.`, `Purchase additional prompts for $60.`)
* a closing action line pointing at the deployment's billing page, so hitting the limit is never a dead end

```
╭─ Prompt limit reached ────────────────────────────────────────────────────────╮
│ You've used 150 of 150 prompts this month.                                    │
│ Upgrade to Pro for more prompts/month.                                        │
│ → Upgrade or buy more prompts: https://app.skyportal.ai/billing/?upgrade=true │
╰───────────────────────────────────────────────────────────────────────────────╯
```

The billing URL comes from a new `SkyportalClient.billing_url()` next to `api_key_url()`, so custom deployments link to their own `/billing/?upgrade=true` page (the same target as the web chat's quota modal CTA). The shell falls back to the production app URL when the client does not expose it.

Details that match the backend contract:

* The branch keys on metadata alone. An empty content string cannot drop the notice into the misleading `no messages to show` fallback, and the structured payload stands in for it.
* A missing or malformed `quota` payload falls back to the notice's content text, still followed by the billing link.
* The suggestion line is skipped when the backend already embedded the same sentence in the fallback text, so nothing renders twice.
* `/resume --verbose` history replay renders the same panel instead of generic prose.

## Rollout

The backend side, SkyportalAi/skyportal-website#3145, is now merged, and the persisted metadata on its main matches this branch exactly (verified against the merge commit). Order still does not matter for deploys: backends without that change never emit this metadata type, so the branch stays dormant against them, and deployed CLIs without this change keep rendering the notice as plain prose.

## Testing

* New `tests/test_shell_prompt_limit.py`: usage line from the quota payload, suggestion from metadata rather than content, billing link with and without a suggestion, custom deployment base URL, production fallback, malformed quota degradation, empty content, history replay, and an end to end `_process_turn` regression proving the rate-limited turn renders the notice instead of the fallback.
* `tests/test_portal.py`: `billing_url()` for custom deployments and marketing host normalization.
* Full suite: `pytest tests/` 463 passed. `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear quota and rate-limit notices to the terminal interface.
  - Displays usage details, upgrade suggestions, and a direct billing/upgrade link.
  - Supports deployment-specific billing pages with a production fallback.
  - Preserves quota notices when replaying conversation history.

- **Bug Fixes**
  - Quota-limit messages now appear even when their message content is empty, instead of showing a generic fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
