### PR TITLE
feat(shell): pick a server when a turn pauses for scope

### DIFF
--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -1304,28 +1304,53 @@ class InteractiveShell:
             self.console.print()
         return rendered
 
-    def _no_server_choices(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """The server options the newest react_no_server pause offered, if any.
+    def _turn_paused_for_scope(self, messages: List[Dict[str, Any]]) -> bool:
+        """True when the turn stopped only because nothing was in scope.
 
-        Read from metadata rather than the prose: the message text names both
-        the web Scope pill and /server because nothing server-side can tell the
-        clients apart, so the terminal renders its own picker from the data.
-        An older website that doesn't send available_servers yields [], and the
-        plain message stands on its own — the CLI ships independently of it.
+        Keyed on the metadata type, not the prose: the message text names both
+        the web Scope pill and /server, because nothing server-side can tell
+        the clients apart.
         """
-        for message in sorted(messages, key=lambda item: self._sequence(item) or 0, reverse=True):
-            metadata = message.get("metadata")
-            if not isinstance(metadata, dict) or metadata.get("type") != "react_no_server":
+        return any(
+            isinstance(message.get("metadata"), dict)
+            and message["metadata"].get("type") == "react_no_server"
+            for message in messages
+        )
+
+    def _no_server_choices(self) -> List[Dict[str, Any]]:
+        """The user's servers, read live — the same list /servers and /server use.
+
+        Deliberately NOT the copy the pause message carries: that one is built
+        from the chat's cached metadata, so a host added after the chat started
+        is missing from it. The CLI already owns a live list; asking for it here
+        means the picker offers exactly what /servers would.
+        """
+        choices = []
+        for server in self._items(self.client.servers()):
+            if not isinstance(server, dict):
                 continue
-            choices = metadata.get("available_servers")
-            if not isinstance(choices, list):
-                return []
-            return [c for c in choices if isinstance(c, dict) and c.get("hostname")]
-        return []
+            name = server.get("name") or server.get("hostname")
+            if not name:
+                continue
+            choices.append({
+                "id": server.get("id"),
+                "hostname": name,
+                "target_kind": server.get("target_kind") or "ssh",
+            })
+        return choices
 
     def _offer_server_choice(self, messages: List[Dict[str, Any]]) -> None:
         """Let the user pick a server by number when a turn paused for scope."""
-        choices = self._no_server_choices(messages)
+        if not self._turn_paused_for_scope(messages):
+            return
+        try:
+            with self.console.status("[cyan]Loading your servers…[/cyan]", spinner="dots"):
+                choices = self._no_server_choices()
+        except PortalError as exc:
+            # The pause message already said what to do; a failed lookup here
+            # must not bury it under a stack trace.
+            self.console.print("[dim]Couldn't load your servers ({}).[/dim]".format(exc))
+            return
         if not choices:
             return
         self.console.print()

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -1078,6 +1078,10 @@ class InteractiveShell:
                             turn.chat_id, turn.status
                         )
                     )
+                # The turn is over; if it stopped only because nothing was in
+                # scope, offer the choice here rather than leaving the user to
+                # retype a /server command from the prose.
+                self._offer_server_choice(turn.messages)
                 return
             if not turn.pending_approvals:
                 raise PortalError(
@@ -1299,6 +1303,58 @@ class InteractiveShell:
         if rendered:
             self.console.print()
         return rendered
+
+    def _no_server_choices(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """The server options the newest react_no_server pause offered, if any.
+
+        Read from metadata rather than the prose: the message text names both
+        the web Scope pill and /server because nothing server-side can tell the
+        clients apart, so the terminal renders its own picker from the data.
+        An older website that doesn't send available_servers yields [], and the
+        plain message stands on its own — the CLI ships independently of it.
+        """
+        for message in sorted(messages, key=lambda item: self._sequence(item) or 0, reverse=True):
+            metadata = message.get("metadata")
+            if not isinstance(metadata, dict) or metadata.get("type") != "react_no_server":
+                continue
+            choices = metadata.get("available_servers")
+            if not isinstance(choices, list):
+                return []
+            return [c for c in choices if isinstance(c, dict) and c.get("hostname")]
+        return []
+
+    def _offer_server_choice(self, messages: List[Dict[str, Any]]) -> None:
+        """Let the user pick a server by number when a turn paused for scope."""
+        choices = self._no_server_choices(messages)
+        if not choices:
+            return
+        self.console.print()
+        for index, choice in enumerate(choices, start=1):
+            kind = "kubernetes" if choice.get("target_kind") == "kubernetes" else "ssh"
+            line = Text("  {}. ".format(index), style="dim")
+            line.append(str(choice["hostname"]), style="bold")
+            line.append("  {}".format(kind), style="dim")
+            self.console.print(line)
+        try:
+            answer = self.session.prompt(
+                "Which server? [1-{}, or Enter to skip]: ".format(len(choices))
+            ).strip()
+        except (KeyboardInterrupt, EOFError):
+            answer = ""
+        if not answer:
+            self.console.print("[dim]No server selected — use /server <name> when you're ready.[/dim]")
+            return
+        try:
+            picked = choices[int(answer) - 1] if 1 <= int(answer) <= len(choices) else None
+        except ValueError:
+            # A name is as good as a number; _cmd_server resolves either.
+            picked = {"hostname": answer}
+        if picked is None:
+            self.console.print("[yellow]That wasn't one of the listed servers.[/yellow]")
+            return
+        # Reuse /server so scope-setting has exactly one implementation.
+        self._cmd_server([str(picked["hostname"])])
+        self.console.print("[dim]Send your message again and I'll run it there.[/dim]")
 
     def _assistant_message_line(self, message: Dict[str, Any]) -> Optional[Any]:
         """Render one assistant-role message, distinguishing the three kinds

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -1370,15 +1370,30 @@ class InteractiveShell:
             self.console.print("[dim]No server selected — use /server <name> when you're ready.[/dim]")
             return
         try:
-            picked = choices[int(answer) - 1] if 1 <= int(answer) <= len(choices) else None
+            index = int(answer)
         except ValueError:
-            # A name is as good as a number; _cmd_server resolves either.
-            picked = {"hostname": answer}
-        if picked is None:
-            self.console.print("[yellow]That wasn't one of the listed servers.[/yellow]")
+            # Not a number: treat it as a name and let /server resolve it.
+            token = answer
+        else:
+            if not 1 <= index <= len(choices):
+                self.console.print("[yellow]That wasn't one of the listed servers.[/yellow]")
+                return
+            picked = choices[index - 1]
+            # The ID, not the hostname. Server.hostname has no unique constraint,
+            # and _resolve_server_tokens' name map is first-wins — so with two
+            # hosts both named "box", picking the SECOND line would silently scope
+            # to the first and print a success message naming it.
+            token = str(picked.get("id") or picked["hostname"])
+        # Reuse /server so scope-setting has exactly one implementation. Its
+        # PortalError for an unresolvable token is handled here: unhandled it
+        # escapes _process_turn into run()'s "Skyportal request failed" banner,
+        # which is a heavy response to a mistyped hostname — and the guidance
+        # below would never print.
+        try:
+            self._cmd_server([token])
+        except PortalError as exc:
+            self.console.print("[yellow]{}[/yellow]".format(exc))
             return
-        # Reuse /server so scope-setting has exactly one implementation.
-        self._cmd_server([str(picked["hostname"])])
         self.console.print("[dim]Send your message again and I'll run it there.[/dim]")
 
     def _assistant_message_line(self, message: Dict[str, Any]) -> Optional[Any]:

--- a/tests/test_shell_no_server_picker.py
+++ b/tests/test_shell_no_server_picker.py
@@ -1,0 +1,152 @@
+"""A turn that paused for scope offers a numbered picker, not just prose.
+
+The server-side message names both the web Scope pill and `/server <name>`
+because nothing at that layer can tell the clients apart. The terminal reads
+the same choices out of metadata['available_servers'] and renders its own
+picker, so a CLI user never has to retype a command out of the prose.
+"""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from skyportal.shell import InteractiveShell
+
+SERVERS = [
+    {"id": "66", "name": "build-box-01", "status": "connected", "host_type": "Dev",
+     "target_kind": "ssh", "vcpu": 8, "ram": 16, "gpus": 0},
+    {"id": "67", "name": "k8s-cp-01", "status": "connected", "host_type": "Dev",
+     "target_kind": "kubernetes", "vcpu": 8, "ram": 16, "gpus": 0},
+]
+
+
+def _pause_message(available=None, sequence=3):
+    metadata = {"type": "react_no_server", "failed_tool": "run_command", "iteration": 1}
+    if available is not None:
+        metadata["available_servers"] = available
+    return {
+        "role": "assistant",
+        "sequence": sequence,
+        "content": "Which server would you like to use for this chat?",
+        "metadata": metadata,
+    }
+
+
+AVAILABLE = [
+    {"id": 66, "hostname": "build-box-01", "target_kind": "ssh"},
+    {"id": 67, "hostname": "k8s-cp-01", "target_kind": "kubernetes"},
+]
+
+
+class FakeClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self):
+        self.single_scope_calls = []
+        self.scope_calls = []
+
+    def is_authenticated(self):
+        return True
+
+    def servers(self):
+        return SERVERS
+
+    def select_chat_server(self, chat_id, server_id):
+        self.single_scope_calls.append((chat_id, server_id))
+
+    def select_chat_servers(self, chat_id, server_ids, active_server_id=None):
+        self.scope_calls.append((chat_id, server_ids, active_server_id))
+
+
+class FakeSession:
+    """Answers the picker prompt; records what it was asked."""
+
+    def __init__(self, answer):
+        self._answer = answer
+        self.prompts = []
+
+    def prompt(self, text, **_kwargs):
+        self.prompts.append(text)
+        return self._answer
+
+
+@pytest.fixture
+def make_shell(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKYPORTAL_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+
+    def _build(answer):
+        out = StringIO()
+        console = Console(file=out, width=160, force_terminal=False)
+        client = FakeClient()
+        session = FakeSession(answer)
+        instance = InteractiveShell(
+            console=console,
+            client_factory=lambda: client,
+            session=session,
+            token_prompt=lambda _prompt: "",
+        )
+        instance.chat_id = 1251
+        return instance, client, session, out
+
+    return _build
+
+
+def test_lists_the_offered_servers_and_selects_by_number(make_shell):
+    instance, client, session, out = make_shell("2")
+    instance._offer_server_choice([_pause_message(AVAILABLE)])
+    text = out.getvalue()
+
+    assert "1." in text and "build-box-01" in text
+    assert "2." in text and "k8s-cp-01" in text
+    assert "kubernetes" in text
+    assert session.prompts and "Which server?" in session.prompts[0]
+    # Picking 2 scopes the chat to k8s-cp-01 through the same path as /server.
+    assert client.single_scope_calls == [(1251, 67)]
+
+
+def test_a_typed_name_works_as_well_as_a_number(make_shell):
+    instance, client, _, _ = make_shell("build-box-01")
+    instance._offer_server_choice([_pause_message(AVAILABLE)])
+
+    assert client.single_scope_calls == [(1251, 66)]
+
+
+def test_enter_skips_without_selecting(make_shell):
+    instance, client, _, out = make_shell("")
+    instance._offer_server_choice([_pause_message(AVAILABLE)])
+
+    assert client.single_scope_calls == []
+    assert "/server <name>" in out.getvalue()
+
+
+def test_silent_when_the_turn_did_not_pause_for_scope(make_shell):
+    instance, client, session, out = make_shell("1")
+    instance._offer_server_choice([
+        {"role": "assistant", "sequence": 2, "content": "done", "metadata": {"type": "react_thought"}},
+    ])
+
+    assert session.prompts == []
+    assert client.single_scope_calls == []
+    assert out.getvalue() == ""
+
+
+def test_older_website_without_available_servers_falls_back_to_prose(make_shell):
+    # The CLI ships independently of the website: a deployment that predates
+    # available_servers must not get a picker with nothing in it.
+    instance, client, session, out = make_shell("1")
+    instance._offer_server_choice([_pause_message(available=None)])
+
+    assert session.prompts == []
+    assert client.single_scope_calls == []
+    assert out.getvalue() == ""
+
+
+def test_reads_the_newest_pause_when_a_chat_has_several(make_shell):
+    instance, client, _, _ = make_shell("1")
+    instance._offer_server_choice([
+        _pause_message([{"id": 9, "hostname": "stale-host", "target_kind": "ssh"}], sequence=1),
+        _pause_message(AVAILABLE, sequence=5),
+    ])
+
+    assert client.single_scope_calls == [(1251, 66)]

--- a/tests/test_shell_no_server_picker.py
+++ b/tests/test_shell_no_server_picker.py
@@ -1,9 +1,10 @@
 """A turn that paused for scope offers a numbered picker, not just prose.
 
 The server-side message names both the web Scope pill and `/server <name>`
-because nothing at that layer can tell the clients apart. The terminal reads
-the same choices out of metadata['available_servers'] and renders its own
-picker, so a CLI user never has to retype a command out of the prose.
+because nothing at that layer can tell the clients apart. The terminal spots
+the pause from the metadata type and then builds the picker from its OWN live
+/servers call — the same list /server resolves against — so the options are
+never a stale snapshot of the chat's cached metadata.
 """
 
 from io import StringIO
@@ -11,6 +12,7 @@ from io import StringIO
 import pytest
 from rich.console import Console
 
+from skyportal.portal import PortalError
 from skyportal.shell import InteractiveShell
 
 SERVERS = [
@@ -45,11 +47,14 @@ class FakeClient:
     def __init__(self):
         self.single_scope_calls = []
         self.scope_calls = []
+        self.fail_with = None
 
     def is_authenticated(self):
         return True
 
     def servers(self):
+        if self.fail_with is not None:
+            raise self.fail_with
         return SERVERS
 
     def select_chat_server(self, chat_id, server_id):
@@ -131,22 +136,34 @@ def test_silent_when_the_turn_did_not_pause_for_scope(make_shell):
     assert out.getvalue() == ""
 
 
-def test_older_website_without_available_servers_falls_back_to_prose(make_shell):
-    # The CLI ships independently of the website: a deployment that predates
-    # available_servers must not get a picker with nothing in it.
-    instance, client, session, out = make_shell("1")
+def test_offers_hosts_the_pause_message_never_listed(make_shell):
+    # The whole reason the list is fetched rather than read off the message:
+    # the message's copy comes from the chat's cached metadata, so a host added
+    # after the chat started is missing from it. /servers has it, so we do too.
+    instance, client, _, out = make_shell("2")
+    instance._offer_server_choice([
+        _pause_message([{"id": 66, "hostname": "build-box-01", "target_kind": "ssh"}]),
+    ])
+
+    assert "k8s-cp-01" in out.getvalue()
+    assert client.single_scope_calls == [(1251, 67)]
+
+
+def test_works_against_a_website_that_sends_no_server_list(make_shell):
+    # available_servers is not required — the metadata type alone marks the
+    # pause, so the picker works against a backend that never ships the field.
+    instance, client, _, out = make_shell("1")
     instance._offer_server_choice([_pause_message(available=None)])
+
+    assert "build-box-01" in out.getvalue()
+    assert client.single_scope_calls == [(1251, 66)]
+
+
+def test_a_failed_server_lookup_does_not_bury_the_message(make_shell):
+    instance, client, session, out = make_shell("1")
+    client.fail_with = PortalError("portal unreachable")
+    instance._offer_server_choice([_pause_message(AVAILABLE)])
 
     assert session.prompts == []
     assert client.single_scope_calls == []
-    assert out.getvalue() == ""
-
-
-def test_reads_the_newest_pause_when_a_chat_has_several(make_shell):
-    instance, client, _, _ = make_shell("1")
-    instance._offer_server_choice([
-        _pause_message([{"id": 9, "hostname": "stale-host", "target_kind": "ssh"}], sequence=1),
-        _pause_message(AVAILABLE, sequence=5),
-    ])
-
-    assert client.single_scope_calls == [(1251, 66)]
+    assert "Couldn't load your servers" in out.getvalue()

--- a/tests/test_shell_no_server_picker.py
+++ b/tests/test_shell_no_server_picker.py
@@ -12,7 +12,7 @@ from io import StringIO
 import pytest
 from rich.console import Console
 
-from skyportal.portal import PortalError
+from skyportal.portal import ChatTurnResult, PortalError
 from skyportal.shell import InteractiveShell
 
 SERVERS = [
@@ -167,3 +167,53 @@ def test_a_failed_server_lookup_does_not_bury_the_message(make_shell):
     assert session.prompts == []
     assert client.single_scope_calls == []
     assert "Couldn't load your servers" in out.getvalue()
+
+
+def test_the_picker_actually_fires_from_process_turn(make_shell):
+    """End to end through _process_turn, which is the ONLY place the picker fires.
+
+    Every other test here calls _offer_server_choice directly, so deleting that
+    single call site would leave the feature dead for real users while the suite
+    stayed green — verified: it does. This test fails when the WIRING goes, not
+    only when the method does.
+    """
+    instance, client, session, out = make_shell("2")
+    turn = ChatTurnResult(1251, "idle", [_pause_message(AVAILABLE)], [], 3)
+
+    instance._process_turn(turn)
+
+    assert session.prompts and "Which server?" in session.prompts[0]
+    assert "k8s-cp-01" in out.getvalue()
+    assert client.single_scope_calls == [(1251, 67)]
+
+
+def test_duplicate_hostnames_select_the_line_the_user_pointed_at(make_shell):
+    """Server.hostname has no unique constraint and _resolve_server_tokens' name
+    map is first-wins, so resolving a numeric pick BY NAME scoped the chat to the
+    wrong host — while printing a success message naming it."""
+    instance, client, _, _ = make_shell("2")
+    instance.client._payload = [
+        {"id": "66", "name": "box", "status": "connected", "host_type": "Dev",
+         "target_kind": "ssh", "vcpu": 8, "ram": 16, "gpus": 0},
+        {"id": "67", "name": "box", "status": "connected", "host_type": "Dev",
+         "target_kind": "ssh", "vcpu": 8, "ram": 16, "gpus": 0},
+    ]
+
+    instance._offer_server_choice([_pause_message(AVAILABLE)])
+
+    # Line 2 must scope to 67, not to the first "box".
+    assert client.single_scope_calls == [(1251, 67)]
+
+
+def test_a_mistyped_hostname_stays_inside_the_picker(make_shell):
+    """_cmd_server raises PortalError for an unresolvable token. Unhandled it
+    escaped _process_turn into run()'s red "Skyportal request failed" banner — a
+    heavy response to a typo, and inconsistent with the graceful message an
+    out-of-range NUMBER gets."""
+    instance, client, _, out = make_shell("buidl-box-01")
+
+    instance._offer_server_choice([_pause_message(AVAILABLE)])
+
+    assert client.single_scope_calls == []
+    assert "not found in your account" in out.getvalue()
+    assert "Send your message again" not in out.getvalue()


### PR DESCRIPTION
Pairs with **SkyportalAi/skyportal-website#3269**, which emits the pause this reads.

## The problem

Ask the agent anything with no server in scope, and the turn ends with prose telling you to use the **Scope pill** or type `/server`. The pill is web-only — nothing server-side can tell the clients apart (the CLI, browser agent, `headless_ansible` and the Slack bot all enter through `run_agent_in_background()`), so the message has to name both mechanisms.

That left the CLI user reading a web instruction and then retyping a command out of the message. The terminal already knew the answer and made you spell it back.

## The change

`_process_turn` spots the pause from the message metadata (`type == "react_no_server"`) and renders a picker:

```
  1. build-box-01  ssh
  2. k8s-cp-01     kubernetes
  Which server? [1-2, or Enter to skip]: 2
```

- **Options come from the CLI's own live `/servers` call** (`GET /api/v1/experiments/my-servers/`), the same list `/server <name>` resolves against — *not* from the `available_servers` field the pause message carries. That copy is built from the chat's cached metadata, so a host added after the chat started is missing from it; `/servers` would show it and the picker wouldn't. One list, one freshness story.
- **A number or a hostname both work.** A numeric pick passes the server **id**; a typed name resolves by name.
- **Enter skips** and says how to select later.
- Selection goes through `_cmd_server`, so scope-setting keeps one implementation.

`available_servers` is therefore **not required** — the metadata type alone marks the pause, so this works against a website deployment that never ships the field. A failed `/servers` lookup prints one dim line rather than burying the pause message under a traceback.

## Review fixes (`6825112`)

- **Duplicate hostnames selected the wrong host, silently.** The picker captured `picked["id"]` then discarded it, re-resolving by name. `Server.hostname` has no unique constraint and `_resolve_server_tokens`' name map is first-wins, so with two hosts both named `box` (ids 66, 67) picking line **2** scoped to **66** — and printed `✓ Server box selected.`, so nothing looked wrong. Numeric picks now pass the id.
- **A mistyped hostname escaped the picker** into run()'s red "Skyportal request failed" banner, while an out-of-range *number* got a graceful yellow line. Now consistent.
- **The tests never exercised the call site.** All 7 called `_offer_server_choice` directly. Deleting only the one line in `_process_turn` — leaving every method intact, so the picker could never fire for a real user — left the suite green. Three tests added, including one that drives `_process_turn` end to end; re-running that deletion now fails the suite.

## Scope of v1

Stops at setting scope; the user re-sends their message, which is what the server-side text already says. Auto-resending would need the turn's original text carried through the pause — worth doing, but it's state this doesn't have yet.

## Testing

10 tests on the picker: numbered selection, hostname selection, skip, non-pause turns, the missing-field fallback, a failed lookup, end-to-end through `_process_turn`, duplicate hostnames, and a mistyped hostname. 473 in the suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive server picker when a chat response requires server selection.
  * Displays available servers with numbered hostname and type options.
  * Supports selecting a server by number or hostname, then resending the message.
  * Allows users to skip selection by submitting an empty response.

* **Bug Fixes**
  * Improved handling of responses with missing, unrelated, or legacy server-selection information.
  * Invalid selections now remain in the picker for another attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->