### PR TITLE
ci(release): publish to PyPI via Trusted Publishing on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,17 @@ jobs:
             exit 1
           fi
 
+      # workflow_dispatch skips the tag guard above (there is no tag to check),
+      # so a dispatch aimed at real PyPI would otherwise publish an unguarded
+      # version from any branch. PyPI never allows re-uploading a version, so
+      # restrict that combination to the default branch. TestPyPI stays open:
+      # dry-running a branch is the point.
+      - name: Refuse a PyPI dispatch from outside the default branch
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          echo "::error::publishing to PyPI by hand is only allowed from ${{ github.event.repository.default_branch }} (got ${GITHUB_REF_NAME}). Tag a release instead, or dispatch against testpypi."
+          exit 1
+
       - name: Build
         run: uv build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      # A tag that disagrees with pyproject.toml would publish a version nobody
+      # can reproduce from the tag, and PyPI never allows re-uploading it.
+      - name: Verify tag matches project version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          project_version="$(uv version --short)"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$project_version" != "$tag_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME implies $tag_version but pyproject.toml declares $project_version"
+            exit 1
+          fi
+
+      - name: Build
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check --strict dist/*
+
+      - name: Verify the built wheel installs and runs
+        run: |
+          uv tool install --no-cache ./dist/*.whl
+          skyportalai --version
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}
+      url: https://pypi.org/p/skyportalai
+    permissions:
+      id-token: write # mint the OIDC token Trusted Publishing exchanges for an upload token
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/*
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          print-hash: true


### PR DESCRIPTION
## Change type

- [ ] 🆕 New or changed CLI command / flag
- [x] 🔄 Behavior change (observable difference for users)
- [x] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

`skyportalai` is not published to any package index, so the only way to run
the CLI is to clone the repo and use `./run.sh`. That script currently fails
on a fresh clone: `python3 -m venv` seeds whatever pip ships with the host
interpreter's `ensurepip`, and an older pip (21.2.4 locally) predates
[PEP 660](https://peps.python.org/pep-0660/), so it cannot perform an editable
install against the `poetry-core` build backend:

```
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode
(A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)
```

This PR fixes the root cause rather than the symptom: it publishes the package,
so users install it directly instead of bootstrapping a clone.

Adds `.github/workflows/release.yml`, which builds on a `v*` tag and publishes
to PyPI using **Trusted Publishing** (OIDC) — no long-lived API token is stored
in the repository.

**No changes to `pyproject.toml` were needed.** The existing PEP 621 `[project]`
metadata is already publish-ready; verified end to end locally:

| Step | Result |
|---|---|
| `uv build` | wheel + sdist built via `poetry-core` |
| `twine check` | PASSED on both artifacts |
| `uv tool install ./dist/*.whl` | installed 3 executables |
| `skyportalai --version` | `skyportalai 0.1.0` |

Design notes:

- **Version guard** — the build job fails when the tag disagrees with
  `pyproject.toml`. PyPI never permits re-uploading a version, so a mismatched
  tag would burn that number permanently.
- **Smoke test before publish** — the built wheel is installed and executed in
  CI, so a broken entry point cannot reach the index.
- **TestPyPI dry run** — `workflow_dispatch` can target TestPyPI first.
- All actions are pinned to full commit SHAs, matching the convention in
  `ci.yml`.

---

<!-- ✅ Required when "New or changed CLI command / flag" is checked -->
## CLI usage example

Not applicable — no CLI command or flag changed. This PR only changes how the
existing CLI is distributed.

Docs updated: N/A – no public docs affected by this PR (see "Known leftovers").

---

## Before / after

**Before:** No install path exists. Users must `git clone` and run `./run.sh`,
which fails on a fresh clone wherever the host seeds a pre-PEP 660 pip.

**After:** Once the tag is pushed and the publisher is registered (see setup
below), the CLI installs directly with no clone:

```bash
uv tool install skyportalai   # or: uvx skyportalai, pipx install skyportalai
skyportalai --version
```

Test coverage: not unit-testable (CI-only change). Validated by executing the
full chain locally — build → `twine check --strict` → `uv tool install` → run —
and the workflow itself re-runs that same chain on every release, gating the
publish step on it. Existing suite: **463 passed**.

---

## Security callout

This PR adds a workflow that holds publish rights to the `skyportalai` PyPI
project. That is the entire threat-model impact: nothing in the CLI's own auth,
credential, or kubeconfig handling changes.

How the risk is mitigated:

- **Trusted Publishing (OIDC)** — GitHub mints a short-lived token that PyPI
  exchanges for a temporary upload token. No long-lived secret exists in the
  repo to leak, and there is no token to rotate. This is specifically what
  avoids adding a `PYPI_API_TOKEN` secret; **no new credentials or secrets are
  introduced by this PR.**
- **Least privilege** — `id-token: write` is scoped to the `publish` job alone.
  The `build` job runs read-only, so a compromised build or test step cannot
  reach the index. The top-level default is `contents: read`.
- **Environment gate** — publishing runs in a named GitHub environment, so a
  required reviewer can be added to force manual approval before any upload.
- **SHA-pinned actions** — every action is pinned to an immutable commit SHA
  rather than a mutable tag, so a hijacked tag cannot inject code into the job
  that holds publish rights.
- **Build provenance** — signed attestations link each artifact to the commit
  and workflow that produced it.
- **Checkout hardening** — `persist-credentials: false`.

---

## Validation

- [x] Tests added or updated where behavior changed *(N/A — CI-only change; validated by running the full release chain locally, see above)*
- [x] `poetry run pytest` passes *(463 passed)*
- [x] `poetry run ruff check .` passes *(All checks passed)*
- [x] Public API/configuration changes are documented *(setup steps below; README follow-up noted)*
- [x] No credentials or private run data are included

---

## ⚠️ Required setup before this can publish

This workflow cannot succeed until a PyPI account owner completes these steps —
they need PyPI access and cannot be done from the repo:

1. **Register a pending publisher on PyPI** (this is also what reserves the
   as-yet-unclaimed `skyportalai` name — there is no separate claiming step):
   - PyPI → *Your projects* → *Publishing* → *Add a pending publisher*
   - Project `skyportalai`, owner `SkyportalAi`, repo `skyportalai`,
     workflow `release.yml`, environment `pypi`
2. **Optionally repeat on TestPyPI** with environment `testpypi` to enable the
   dry run.
3. **Optionally add a required reviewer** to the `pypi` environment
   (*Settings → Environments*) to enforce manual approval before upload. The
   environments are created automatically on first run with no protection rules.

Recommended first release order — note `workflow_dispatch` only becomes
available once this file is on the default branch:

1. Merge this PR
2. Run *Release* → `workflow_dispatch` → target `testpypi` (dry run)
3. Tag `v0.1.0` and push → publishes to PyPI

## Known leftovers (intentionally out of scope)

- **`./run.sh` still fails on a fresh clone.** It stays useful for contributors
  working from a checkout, but its pip bootstrap needs a separate fix
  (simplest: `uv run skyportal start`).
- **README.md:51** still documents the `./run.sh` flow, and **README.md:209**
  advertises `pip install "skyportalai[agent]"`, which will not work until the
  first release lands. Worth updating in the release PR.
- **Console script collision:** this package installs a `skyportal` executable
  and a top-level `skyportal` import, which collide with the unrelated
  astronomy [`skyportal`](https://pypi.org/project/skyportal/) package on PyPI.
  Harmless unless a user has both, but dropping that entry point is cheap now
  and breaking after there are users.

## Related issue

Closes #
