### PR TITLE
fix(run.sh): bootstrap with uv so a fresh clone works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,15 @@ poetry run ruff check .
 poetry check --strict
 ```
 
+`./run.sh` is a launcher for running the CLI from a checkout; it uses uv and
+installs runtime dependencies only. Both it and Poetry default to `.venv`, so
+running the launcher after `poetry install` prunes the dev tools from that
+environment. Set `SKYPORTAL_VENV` to keep them apart:
+
+```console
+SKYPORTAL_VENV=~/.cache/skyportal-cli ./run.sh
+```
+
 The normal test suite must not contact live services. Use `requests-mock`,
 temporary paths, and environment isolation.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,13 +8,25 @@ From a source checkout:
 ./run.sh
 ```
 
-The launcher creates `.venv`, installs missing Debian/Ubuntu virtual-environment or pip support when possible, installs the package in editable mode, and starts `skyportal`.
+The launcher installs [uv](https://docs.astral.sh/uv/) if it is missing, provisions the Python version pinned in `.python-version`, installs the project and its dependencies, and starts `skyportal`.
+
+Set `SKYPORTAL_VENV` to place the environment somewhere other than `.venv`.
 
 ## Manual installation
 
 ```bash
+uv sync --no-dev
+uv run skyportal
+```
+
+Without uv, note that an editable install needs a pip new enough to support
+[PEP 660](https://peps.python.org/pep-0660/) (pip 21.3+), because this project
+builds with `poetry-core` rather than setuptools:
+
+```bash
 python3 -m venv .venv
 . .venv/bin/activate
+python -m pip install --upgrade pip
 python -m pip install -e .
 skyportal
 ```
@@ -72,9 +84,16 @@ Use `skyportal ask` for a one-shot agent request. Interactive approvals require 
 
 ## Troubleshooting
 
-### Virtual environment has no pip
+### Virtual environment is broken or has no pip
 
-Rerun `./run.sh`; it tries `ensurepip`, Debian/Ubuntu Python packages, and the official pip bootstrap in sequence.
+Delete `.venv` and rerun `./run.sh`. uv rebuilds the environment from scratch
+and does not depend on the interpreter's bundled pip.
+
+### `Directory cannot be installed in editable mode`
+
+Raised by a pip older than 21.3, which predates PEP 660 and cannot install a
+`poetry-core` project in editable mode. Use `./run.sh`, or upgrade pip first
+with `python -m pip install --upgrade pip`.
 
 ### Access denied
 
@@ -89,4 +108,4 @@ Return to the `/keys/` URL printed in the terminal. The product website also pre
 
 ### Cloudflare blocks the request
 
-Current releases send an explicit `Skyportal-CLI` user agent. Reinstall the editable package with `./run.sh` if an older process still identifies itself as Python's default URL client.
+Current releases send an explicit `Skyportal-CLI` user agent. Reinstall with `./run.sh` if an older process still identifies itself as Python's default URL client.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,6 +12,15 @@ The launcher installs [uv](https://docs.astral.sh/uv/) if it is missing, provisi
 
 Set `SKYPORTAL_VENV` to place the environment somewhere other than `.venv`.
 
+Contributors who also run `poetry install` should do so: both tools default to
+`.venv`, and the launcher installs runtime dependencies only, so running it
+afterwards prunes `pytest`, `ruff` and the `agent` extra from that environment.
+Either point the launcher elsewhere, or rerun `poetry install --all-extras`.
+
+```bash
+SKYPORTAL_VENV=~/.cache/skyportal-cli ./run.sh
+```
+
 ## Manual installation
 
 ```bash

--- a/run.sh
+++ b/run.sh
@@ -1,124 +1,50 @@
 #!/usr/bin/env bash
-# Intentionally no `set -e`: every fallible step below is checked explicitly so
-# that we can fall through to the next recovery strategy instead of aborting.
-set -uo pipefail
+# Bootstraps a source checkout and starts the CLI.
+#
+# Everything below delegates to uv, which provisions the interpreter pinned in
+# .python-version, resolves dependencies and installs the project in one step.
+# The previous hand-rolled ladder (venv -> ensurepip -> apt -> get-pip.py) was
+# removed: a venv seeded with a pre-PEP 660 pip cannot editable-install this
+# project at all, because the build backend is poetry-core rather than
+# setuptools, and the ladder had no way to detect that.
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VENV_DIR="${SKYPORTAL_VENV:-"$ROOT_DIR/.venv"}"
-PY_MINOR="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
 
 log() {
   echo "run.sh: $*" >&2
 }
 
-# Installs one or more apt packages. Returns 1 (without aborting the script)
-# if apt-get is unavailable or the install fails, so callers can try the next
-# recovery strategy.
-apt_install() {
-  local -a packages=("$@")
-  local -a apt_cmd=(apt-get)
+# Honour the historical override so existing scripts keep working.
+if [[ -n "${SKYPORTAL_VENV:-}" ]]; then
+  export UV_PROJECT_ENVIRONMENT="$SKYPORTAL_VENV"
+fi
 
-  command -v apt-get >/dev/null 2>&1 || return 1
-  command -v sudo >/dev/null 2>&1 && apt_cmd=(sudo apt-get)
-
-  log "installing ${packages[*]} via apt (you may be prompted for your password)..."
-  "${apt_cmd[@]}" update || log "apt-get update reported an error; continuing anyway."
-  "${apt_cmd[@]}" install -y "${packages[@]}"
-}
-
-venv_has_pip() {
-  [[ -x "$VENV_DIR/bin/python" ]] && "$VENV_DIR/bin/python" -m pip --version >/dev/null 2>&1
-}
-
-# Attempts to create a fully working venv (including pip) with plain `python3 -m venv`.
-create_venv_with_pip() {
-  local err_log
-  err_log="$(mktemp)"
-
-  if python3 -m venv "$VENV_DIR" >"$err_log" 2>&1; then
-    rm -f "$err_log"
-    return 0
-  fi
-
-  if grep -qi "ensurepip" "$err_log"; then
-    cat "$err_log" >&2
-    rm -f "$err_log"
-    log "installing python${PY_MINOR}-venv to provide ensurepip support..."
-    if apt_install "python${PY_MINOR}-venv" || apt_install python3-venv; then
-      rm -rf "$VENV_DIR"
-      if python3 -m venv "$VENV_DIR" >"$err_log" 2>&1; then
-        rm -f "$err_log"
-        return 0
-      fi
-      cat "$err_log" >&2
-    fi
-  else
-    cat "$err_log" >&2
-  fi
-
-  rm -f "$err_log"
-  return 1
-}
-
-# Last-resort recovery that needs neither apt nor sudo: build the venv skeleton
-# without pip, then bootstrap pip via the official get-pip.py installer.
-bootstrap_pip_with_getpip() {
-  rm -rf "$VENV_DIR"
-  python3 -m venv --without-pip "$VENV_DIR" || return 1
-
-  local get_pip
-  get_pip="$(mktemp --suffix=.py)"
+install_uv() {
+  log "uv not found; installing it to ~/.local/bin ..."
 
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL https://bootstrap.pypa.io/get-pip.py -o "$get_pip" || { rm -f "$get_pip"; return 1; }
+    curl -LsSf https://astral.sh/uv/install.sh | sh
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO "$get_pip" https://bootstrap.pypa.io/get-pip.py || { rm -f "$get_pip"; return 1; }
+    wget -qO- https://astral.sh/uv/install.sh | sh
   else
-    log "neither curl nor wget is available to fetch get-pip.py."
-    rm -f "$get_pip"
-    return 1
+    log "neither curl nor wget is available to download uv."
+    log "Install it manually (https://docs.astral.sh/uv/getting-started/installation/) and rerun ./run.sh"
+    exit 1
   fi
 
-  "$VENV_DIR/bin/python" "$get_pip" -q
-  local status=$?
-  rm -f "$get_pip"
-  return $status
+  # The installer does not touch the PATH of the shell that invoked it.
+  export PATH="${XDG_BIN_HOME:-${XDG_DATA_HOME:-$HOME/.local}/bin}:$HOME/.local/bin:$PATH"
 }
 
-ensure_venv() {
-  if venv_has_pip; then
-    return 0
-  fi
+if ! command -v uv >/dev/null 2>&1; then
+  install_uv
+fi
 
-  log "setting up virtual environment at $VENV_DIR"
-
-  if [[ ! -x "$VENV_DIR/bin/python" ]] && create_venv_with_pip && venv_has_pip; then
-    return 0
-  fi
-
-  # venv exists but pip is missing: try ensurepip directly first.
-  if [[ -x "$VENV_DIR/bin/python" ]] && "$VENV_DIR/bin/python" -m ensurepip --upgrade >/dev/null 2>&1 && venv_has_pip; then
-    return 0
-  fi
-
-  # Try installing the system pip package, then rebuild the venv.
-  if apt_install "python${PY_MINOR}-pip" || apt_install python3-pip; then
-    rm -rf "$VENV_DIR"
-    create_venv_with_pip
-    venv_has_pip && return 0
-  fi
-
-  log "falling back to 'venv --without-pip' plus get-pip.py bootstrap..."
-  if bootstrap_pip_with_getpip && venv_has_pip; then
-    return 0
-  fi
-
-  log "failed to provision pip in $VENV_DIR."
-  log "Please run: sudo apt install python${PY_MINOR}-venv python3-pip, then rerun ./run.sh"
+if ! command -v uv >/dev/null 2>&1; then
+  log "uv is installed but not on PATH. Open a new shell, or add ~/.local/bin to PATH, then rerun ./run.sh"
   exit 1
-}
+fi
 
-ensure_venv
-
-"$VENV_DIR/bin/python" -m pip install -q -e "$ROOT_DIR"
-exec "$VENV_DIR/bin/skyportal" start
+cd "$ROOT_DIR"
+exec uv run --no-dev skyportal start "$@"


### PR DESCRIPTION
## Change type

- [ ] 🆕 New or changed CLI command / flag
- [x] 🔄 Behavior change (observable difference for users)
- [ ] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

`./run.sh` fails on a fresh clone:

```
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode
(A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)
...
run.sh: line 124: .venv/bin/skyportal: No such file or directory
```

**The message is misleading — nothing is wrong with `pyproject.toml`.**
`python3 -m venv` seeds whatever pip ships in the host interpreter's
`ensurepip` wheel (pip **21.2.4**, from 2021, on my machine). Any pip older
than 21.3 predates [PEP 660](https://peps.python.org/pep-0660/), the standard
that lets a non-setuptools backend support `pip install -e`. This project
builds with `poetry-core`, so that pip simply cannot install it.

The old script checked that `pip --version` *succeeded*, never that it was
recent enough — so all ~120 lines of `venv` → `ensurepip` → `apt` →
`get-pip.py` recovery ran green and the install still failed.

This replaces the ladder with `uv`, removing the failure mode instead of
patching it. `uv` is a standalone binary, so there is no chicken-and-egg pip
bootstrap: it provisions the interpreter pinned in `.python-version`, resolves
dependencies, installs the project, and runs it in one step.

`run.sh` goes from **134 lines to 50**. `SKYPORTAL_VENV` is still honoured (via
`UV_PROJECT_ENVIRONMENT`), so existing scripts keep working.

No changes to `pyproject.toml` were needed — `uv` reads the existing PEP 621
`[project]` table and drives the existing `poetry-core` backend unchanged.
**CI and the Poetry dev workflow are untouched by this PR.**

---

<!-- ✅ Required when "New or changed CLI command / flag" is checked -->
## CLI usage example

Not applicable — no command or flag changed. `./run.sh` is invoked exactly as
before.

Docs updated: `docs/deployment.md`

---

## Before / after

**Before:** on a fresh clone, `./run.sh` aborts with the editable-install error
above and never starts the CLI, wherever the host seeds a pre-PEP 660 pip.

**After:** `./run.sh` provisions the environment and launches the CLI. Verified
end to end:

```
$ ./run.sh
Using CPython 3.11.13 interpreter at: /opt/homebrew/opt/python@3.11/bin/python3.11
Creating virtual environment at: .venv
Installed 22 packages in 41ms
skyportal, version 0.1.0
```

Test coverage: covered by existing tests — **463 passed**, `ruff` clean. The
script itself is not unit-testable, so it was validated by executing it in
three states:

| Scenario | Result |
|---|---|
| Fresh checkout, no `.venv` | environment created, CLI runs |
| `SKYPORTAL_VENV=/tmp/custom-venv` | env created at the override, `.venv` correctly not created |
| **`.venv` pre-seeded with pip 21.2.4** — reproduces the original bug | uv discards the stale env, rebuilds, CLI runs |

The third row is the meaningful one: it recreates the exact state that breaks
the current script, confirming this actually fixes the reported failure rather
than merely avoiding it on a clean machine.

The documented manual path (`uv sync --no-dev && uv run skyportal`) was run
too.

---

<!-- ✅ Required when "Security-sensitive change" is checked -->
## Security callout

Not applicable — no auth, credential, kubeconfig, or secret handling changes.

One note for reviewers: when `uv` is absent, the script installs it via the
official `https://astral.sh/uv/install.sh` (curl-pipe-sh), which is the
vendor-documented installation method. If you would rather not have the script
install anything implicitly, I am happy to change it to print instructions and
exit instead — say the word.

---

## Validation

- [x] Tests added or updated where behavior changed *(existing suite; script validated in the three states above)*
- [x] `poetry run pytest` passes *(463 passed)*
- [x] `poetry run ruff check .` passes *(All checks passed)*
- [x] Public API/configuration changes are documented *(`docs/deployment.md`)*
- [x] No credentials or private run data are included

## Poetry is unaffected — verified

The full CI sequence was run locally against this branch, under Poetry 2.4.1:

| CI step | Result |
|---|---|
| `poetry install --all-extras --no-interaction` | ok |
| `poetry check --strict` | `All set!` |
| `poetry run ruff check .` | `All checks passed!` |
| `poetry run pytest` | **463 passed** |
| `poetry build` | wheel + sdist built |

**One interaction worth knowing about** (documented in `CONTRIBUTING.md` and
`docs/deployment.md`): Poetry and the launcher both default to `.venv`, and the
launcher installs runtime dependencies only. So running `./run.sh` after
`poetry install` prunes `pytest`, `ruff` and the `agent` extra out of that
environment — `uv sync` enforces an exact match against declared dependencies
and does not know about Poetry's dev group.

This is **not introduced by this PR** — the old launcher installed into `.venv`
too — but it only became reachable now that the launcher gets far enough to
succeed. Two clean ways out, both verified:

```bash
poetry install --all-extras            # restores the dev env in one command
SKYPORTAL_VENV=~/.cache/skyportal-cli ./run.sh   # or keep them fully separate
```

## Notes

- `docs/deployment.md` documented the removed recovery ladder, so it is updated
  here, including a new troubleshooting entry for the editable-mode error aimed
  at anyone installing **without** uv.
- Related: #48 publishes the package to PyPI, which removes the need for a
  source checkout for most users. The two PRs are independent and touch
  disjoint files; either can merge first. `run.sh` stays useful for
  contributors regardless.
- `uv` does **not** read `[tool.poetry.group.dev.dependencies]` (a
  Poetry-proprietary table), so `uv run pytest` will not work until those move
  to PEP 735 `[dependency-groups]`. Out of scope here — this PR only changes
  the runtime launcher; contributors and CI continue to use Poetry.

## Related issue

Closes #
