### PR TITLE
feat(cli)!: expose a single `skyportalai` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Inside the terminal, run `/login` once, list infrastructure with `/servers`,
 select one or more hosts with `/server`, and ask what changed:
 
 ```text
-skyportal [connected] > diagnose the latest deployment
+skyportalai [connected] > diagnose the latest deployment
 ```
 
 Useful commands:

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,6 +1,6 @@
 # Observability agent
 
-`skyportal-agent` discovers local Weights & Biases and MLflow runs, stores new
+`skyportalai-agent` discovers local Weights & Biases and MLflow runs, stores new
 run batches in a bounded disk queue, and sends them to SkyPortal. It is intended
 for a dedicated host or container with only the experiment volumes it needs.
 
@@ -9,7 +9,7 @@ for a dedicated host or container with only the experiment volumes it needs.
 ```console
 pip install "skyportalai[agent]"
 export SKYPORTAL_AGENT_TOKEN='agt_...'
-skyportal-agent
+skyportalai-agent
 ```
 
 The agent exposes `GET /healthz` on port 8080 and handles `SIGTERM`/`SIGINT` with
@@ -22,7 +22,7 @@ a final delivery attempt.
 | `SKYPORTAL_AGENT_TOKEN` | required | Host-bound observability upload token |
 | `SKYPORTAL_BASE_URL` | `https://app.skyportal.ai` | SkyPortal API root |
 | `SKYPORTAL_AGENT_INTERVAL_SECONDS` | `60` | Seconds between scans |
-| `SKYPORTAL_AGENT_STATE_DIR` | `/var/lib/skyportal-agent` | Catalog and delivery spool |
+| `SKYPORTAL_AGENT_STATE_DIR` | `/var/lib/skyportalai-agent` | Catalog and delivery spool |
 | `SKYPORTAL_AGENT_QUEUE_MAX_BATCHES` | `1000` | Maximum on-disk batches |
 | `SKYPORTAL_AGENT_HEALTHZ_PORT` | `8080` | Liveness endpoint port |
 | `SKYPORTAL_AGENT_ENABLE_WANDB` | `true` | Enable W&B discovery |
@@ -38,7 +38,7 @@ For REST-backed MLflow discovery:
 ```console
 export SKYPORTAL_AGENT_MLFLOW_MODE=rest
 export SKYPORTAL_AGENT_MLFLOW_TRACKING_URI=https://mlflow.example
-skyportal-agent
+skyportalai-agent
 ```
 
 ## Data and privacy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Skyportal CLI architecture
 
-The distribution exposes two frontends. `skyportal` is the persistent Click /
+The distribution exposes two frontends. `skyportalai` is the persistent Click /
 prompt-toolkit terminal described below. `skyportalai` is a Typer interface for
 automation and calls the public `skyportalai.Skyportal` SDK resources, with
 optional stable JSON output.
@@ -74,8 +74,8 @@ website serializes REST and browser turns and scope mutations with the same
 token-owned Redis lease, rejects changes while approvals are pending, and
 renews the lease during long turns; losing ownership cancels the local worker
 instead of allowing two clients to execute against different scopes.
-The interactive `skyportal` shell accepts multiple IDs with `/server 12 18`,
-and the one-shot `skyportal ask` command accepts repeated `--server` options.
+The interactive `skyportalai` shell accepts multiple IDs with `/server 12 18`,
+and the one-shot `skyportalai ask` command accepts repeated `--server` options.
 
 ## Local state
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,7 @@ From a source checkout:
 ./run.sh
 ```
 
-The launcher creates `.venv`, installs missing Debian/Ubuntu virtual-environment or pip support when possible, installs the package in editable mode, and starts `skyportal`.
+The launcher creates `.venv`, installs missing Debian/Ubuntu virtual-environment or pip support when possible, installs the package in editable mode, and starts `skyportalai`.
 
 ## Manual installation
 
@@ -16,23 +16,23 @@ The launcher creates `.venv`, installs missing Debian/Ubuntu virtual-environment
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install -e .
-skyportal
+skyportalai
 ```
 
 Python 3.11 or newer is required.
 
 ## Connect to production
 
-The default application URL is `https://app.skyportal.ai`. Run `skyportal login`, create an account API key on the browser page, and paste the `sk_` value into the hidden prompt.
+The default application URL is `https://app.skyportal.ai`. Run `skyportalai login`, create an account API key on the browser page, and paste the `sk_` value into the hidden prompt.
 
 To use an existing key non-persistently:
 
 ```bash
 export SKYPORTAL_API_KEY='sk_...'
-skyportal
+skyportalai
 ```
 
-`skyportal` also accepts `SKYPORTAL_ACCESS_TOKEN` for compatibility.
+`skyportalai` also accepts `SKYPORTAL_ACCESS_TOKEN` for compatibility.
 
 Avoid putting credentials directly in shell history. Do not use `agt_` observability-agent tokens with the CLI.
 
@@ -40,7 +40,7 @@ Avoid putting credentials directly in shell history. Do not use `agt_` observabi
 
 ```bash
 skyportal configure --portal-url https://skyportal.example
-skyportal login
+skyportalai login
 ```
 
 The configured deployment and credential deployment must match.
@@ -57,7 +57,7 @@ skyportalai config show
 skyportalai --json chat send --server 42 "Show disk usage"
 ```
 
-Use the interactive `skyportal` command when a chat may require an approval
+Use the interactive `skyportalai` command when a chat may require an approval
 prompt.
 
 ## Noninteractive terminals
@@ -65,10 +65,10 @@ prompt.
 Disable animation for logs or automation:
 
 ```bash
-SKYPORTAL_NO_ANIMATION=1 skyportal servers
+SKYPORTAL_NO_ANIMATION=1 skyportalai servers
 ```
 
-Use `skyportal ask` for a one-shot agent request. Interactive approvals require the persistent shell.
+Use `skyportalai ask` for a one-shot agent request. Interactive approvals require the persistent shell.
 
 ## Troubleshooting
 
@@ -79,7 +79,7 @@ Rerun `./run.sh`; it tries `ensurepip`, Debian/Ubuntu Python packages, and the o
 ### Access denied
 
 - Confirm the URL is the application host, not a marketing site.
-- Run `skyportal login` and create a fresh `sk_` API key.
+- Run `skyportalai login` and create a fresh `sk_` API key.
 - Ensure the key is active and not expired or revoked.
 - An `agt_` token cannot authorize account or chat operations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,8 @@ dependencies = [
 agent = ["wandb>=0.28.1,<1.0"]
 
 [project.scripts]
-skyportal-agent = "skyportalai.agent.__main__:main"
-skyportal = "skyportal.cli:main"
 skyportalai = "skyportalai.cli:main"
+skyportalai-agent = "skyportalai.agent.__main__:main"
 
 [project.urls]
 Homepage = "https://skyportal.ai"

--- a/run.sh
+++ b/run.sh
@@ -121,4 +121,4 @@ ensure_venv() {
 ensure_venv
 
 "$VENV_DIR/bin/python" -m pip install -q -e "$ROOT_DIR"
-exec "$VENV_DIR/bin/skyportal" start
+exec "$VENV_DIR/bin/skyportalai" start

--- a/skyportal/shell.py
+++ b/skyportal/shell.py
@@ -276,7 +276,7 @@ class InteractiveShell:
         else:
             state_style, state = "class:guest", "guest"
         fragments: List[Tuple[str, str]] = [
-            ("class:brand", "skyportal"),
+            ("class:brand", "skyportalai"),
             ("", " ["),
             (state_style, state),
             ("", "]"),

--- a/skyportalai/cli/__init__.py
+++ b/skyportalai/cli/__init__.py
@@ -1,11 +1,29 @@
 """Public command-line interface for the SkyPortal SDK."""
 
 
+def build_cli():
+    """Return the single Click group exposing every `skyportalai` command.
+
+    The interactive shell is a Click group and the API client is a Typer app.
+    Typer compiles to Click, so the two command sets are merged here rather
+    than either one being rewritten. Imports stay inside the function because
+    Typer and Rich are slow to import and this runs on every invocation.
+    """
+    import typer
+
+    from skyportal.cli import main as shell_group
+
+    from .main import app
+
+    for name, command in typer.main.get_command(app).commands.items():
+        shell_group.add_command(command, name)
+
+    return shell_group
+
+
 def main() -> None:
-    """Load the Typer application only when the console script runs."""
-    from .main import main as run
-
-    run()
+    """Console-script entry point."""
+    build_cli()()
 
 
-__all__ = ["main"]
+__all__ = ["build_cli", "main"]

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -111,7 +111,7 @@ def test_prompt_uses_compact_reference_style():
 
     text = "".join(part[1] for part in shell._prompt_fragments())
 
-    assert text == "skyportal [connected]  > "
+    assert text == "skyportalai [connected]  > "
 
 
 def test_exit_still_completes_after_completion_message():


### PR DESCRIPTION
## Change type

- [x] 🆕 New or changed CLI command / flag
- [x] 🔄 Behavior change (observable difference for users)
- [ ] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [ ] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

The package ships **three** console scripts today, and two of them are
*different CLIs with disjoint command sets*:

| Script | Framework | Commands |
|---|---|---|
| `skyportal` | Click group | `start`, `login`, `logout`, `ask`, `servers`, `configure`, `github-token` |
| `skyportalai` | Typer app | `config`, `chat`, `ansible`, `kubernetes` |
| `skyportal-agent` | — | the observability daemon |

So half the functionality is reachable only under `skyportal` — a name that
also collides with the unrelated astronomy
[`skyportal`](https://pypi.org/project/skyportal/) project on PyPI, for both
the executable on `PATH` and the top-level import.

Everything is now `skyportalai`:

```
skyportalai        all 11 commands (previously split across two entry points)
skyportalai-agent  the observability daemon (was skyportal-agent)
```

Typer compiles to Click, so `build_cli()` attaches the Typer app's commands to
the shell's Click group — **neither CLI is rewritten**, both keep their
existing implementations. Imports stay inside the function to preserve the
existing deferred-import behaviour (Typer and Rich are slow to import, and this
runs on every invocation). Bare `skyportalai` still opens the interactive
shell, via the group's `invoke_without_command=True`.

### Deliberately unchanged

Module paths (`skyportal.cli`, `skyportal.shell`, …), the `~/.skyportal`
config directory, and `SKYPORTAL_*` environment variables. Those are internal
or would break existing installs, and neither is part of the executable-name
collision. `docs/architecture.md`'s module list is left as-is for that reason.

---

## CLI usage example

```console
# before — functionality split across two commands
$ skyportal start
$ skyportal servers
$ skyportalai ansible list

# after — one command
$ skyportalai start
$ skyportalai servers
$ skyportalai ansible list
```

```console
$ skyportalai --help
Commands:
  ansible       Create, manage, list, and deploy Ansible playbooks...
  ask           Send one message to the Skyportal Agent.
  chat          Create, inspect, approve, and cancel ops-agent chats.
  config        Inspect or update CLI connection settings.
  configure     Save Skyportal connection settings.
  github-token  Manage the GitHub Personal Access Token used for git clone.
  kubernetes    Connect Kubernetes clusters and make them available to...
  login         Create or paste an account API key and connect the CLI.
  logout        Remove locally stored Skyportal credentials.
  servers       List servers owned by the connected account.
  start         Launch the persistent Skyportal command center.
```

Docs updated: `README.md`, `docs/deployment.md`, `docs/agent.md`,
`docs/architecture.md`

---

## Before / after

**Before:** `skyportal` and `skyportalai` are two separate CLIs; the shell,
login and server commands live only under the colliding `skyportal` name.

**After:** one `skyportalai` command exposes all 11. Installing the package
puts exactly two executables on `PATH`, both `skyportalai`-prefixed, and
nothing named `skyportal`:

```
$ uv tool install ./dist/skyportalai-0.1.0-py3-none-any.whl
Installed 2 executables: skyportalai, skyportalai-agent

$ command -v skyportal      # correctly absent
```

The shell prompt renders `skyportalai [connected] >` to match.

Test coverage: `tests/test_shell_cancel.py::test_prompt_uses_compact_reference_style`
asserts the prompt string and is updated with the rename. **Revert-verified**:
restoring the old prompt in `shell.py` makes the updated test fail, confirming
it checks the rename rather than passing vacuously.

Verified from a real install, not just `--help` output: a Typer-side subcommand
(`skyportalai ansible --help`), a Click-side subcommand (`skyportalai servers
--help`, whose usage line correctly reads `skyportalai servers`), and
`skyportalai-agent` (which reaches its expected "no agent token" error, proving
the entry point resolves).

---

## Validation

- [x] Tests added or updated where behavior changed *(prompt assertion updated + revert-verified)*
- [x] `poetry run pytest` passes *(463 passed)*
- [x] `poetry run ruff check .` passes *(All checks passed)*
- [x] `poetry check --strict` passes *(All set!)* and `poetry build` succeeds
- [x] Public API/configuration changes are documented
- [x] No credentials or private run data are included

---

## ⚠️ Merge order matters — this PR should land before #49

`run.sh` invokes the shell, so it has to name the right command. The two PRs
touch **different lines of `run.sh`**, so git will merge them cleanly in either
order — but only one order produces working software:

1. **This PR first.** It renames the command *and* updates `run.sh` in the same
   commit, so the tree is consistent.
2. **Then #49**, which rewrites `run.sh` to use uv. Its final line still says
   `skyportal start`, correct against today's `main`. **It needs a one-line
   follow-up to `skyportalai start` once this merges** — I deliberately did not
   pre-apply that, because it would break #49 if #49 merged first.

I'm happy to push that one-line update to #49 as soon as this is approved, or
to rebase #49 on this branch instead — whichever you prefer.

Also related: #48 (PyPI release workflow). Landing this **before the first
`v0.1.0` tag** is the point — renaming a command is free now and a breaking
change once anyone has installed the package.

## Related issue

Closes #
