### PR TITLE
Publish to PyPI with Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,97 @@
+name: Publish
+
+# Releases are published to PyPI with Trusted Publishing (OIDC), so no API
+# token is stored in this repository.
+# https://docs.pypi.org/trusted-publishers/
+#
+#   - Publishing a GitHub Release  -> uploads to pypi.org
+#   - Running this workflow by hand -> uploads to test.pypi.org
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.13
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Install Poetry
+        run: python -m pip install --disable-pip-version-check "poetry==2.4.1"
+      - name: Validate package metadata
+        run: poetry check --strict
+
+      # A PyPI version can never be reused, so refuse to build if the release
+      # tag and the version in pyproject.toml disagree. Tests already pin
+      # pyproject.toml to skyportalai.__version__.
+      - name: Check release tag matches package version
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="$(poetry version --short)"
+          if [ "${RELEASE_TAG#v}" != "$version" ]; then
+            echo "Release tag '$RELEASE_TAG' does not match package version '$version'." >&2
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: poetry build
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/skyportalai
+    permissions:
+      id-token: write # Mints the OIDC token Trusted Publishing exchanges.
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # Re-running a dry run for an already-uploaded version is not an error.
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/skyportalai
+    permissions:
+      id-token: write # Mints the OIDC token Trusted Publishing exchanges.
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Skyportal Agent
 
 [![CI](https://github.com/SkyportalAi/skyportalai/actions/workflows/ci.yml/badge.svg)](https://github.com/SkyportalAi/skyportalai/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/skyportalai.svg)](https://pypi.org/project/skyportalai/)
+[![Python versions](https://img.shields.io/pypi/pyversions/skyportalai.svg)](https://pypi.org/project/skyportalai/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SkyportalAi/skyportalai/blob/main/LICENSE)
 
 An open-source AI infrastructure engineer that explains what changed before
 production breaks.
 
-![Skyportal diagnosing an infrastructure regression](docs/assets/skyportal-diagnose.gif)
+![Skyportal diagnosing an infrastructure regression](https://raw.githubusercontent.com/SkyportalAi/skyportalai/main/docs/assets/skyportal-diagnose.gif)
 
 Skyportal continuously builds a timeline of your AI infrastructure by observing
 deployments, Kubernetes events, GPU metrics, configuration changes, logs, and
@@ -44,6 +46,13 @@ the most likely change, and report its confidence.
 ## Get started
 
 Requires Python 3.11 or newer.
+
+```bash
+pip install skyportalai
+skyportal
+```
+
+Or run from a checkout:
 
 ```bash
 git clone https://github.com/SkyportalAi/skyportalai.git
@@ -209,7 +218,7 @@ running the agent on experiment volumes:
 pip install "skyportalai[agent]"
 ```
 
-See [agent deployment and data handling](docs/agent.md).
+See [agent deployment and data handling](https://github.com/SkyportalAi/skyportalai/blob/main/docs/agent.md).
 
 ## Development
 
@@ -220,9 +229,10 @@ poetry run ruff check .
 poetry check --strict
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) to contribute. Report security issues
-privately using [SECURITY.md](SECURITY.md).
+See [CONTRIBUTING.md](https://github.com/SkyportalAi/skyportalai/blob/main/CONTRIBUTING.md) to contribute, and
+[RELEASING.md](https://github.com/SkyportalAi/skyportalai/blob/main/docs/RELEASING.md) to cut a release. Report security issues
+privately using [SECURITY.md](https://github.com/SkyportalAi/skyportalai/blob/main/SECURITY.md).
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/SkyportalAi/skyportalai/blob/main/LICENSE)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing
+
+`skyportalai` is published to PyPI by
+[`.github/workflows/publish.yml`](../.github/workflows/publish.yml) using
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/). PyPI verifies a
+short-lived OIDC token minted by GitHub Actions, so there is no API token in
+this repository and nothing to rotate.
+
+- Publishing a **GitHub Release** uploads to [pypi.org](https://pypi.org).
+- Running the workflow **manually** (Actions → Publish → Run workflow) uploads
+  to [test.pypi.org](https://test.pypi.org) for a dry run.
+
+## One-time setup
+
+Do this once per index, from an account that owns the project. Because
+`skyportalai` has not been published yet, register it as a *pending* publisher —
+the project is created on the first successful upload.
+
+1. **PyPI** → <https://pypi.org/manage/account/publishing/>, add a pending
+   publisher:
+
+   | Field | Value |
+   | --- | --- |
+   | PyPI Project Name | `skyportalai` |
+   | Owner | `SkyportalAi` |
+   | Repository name | `skyportalai` |
+   | Workflow name | `publish.yml` |
+   | Environment name | `pypi` |
+
+2. **TestPyPI** → <https://test.pypi.org/manage/account/publishing/>, same
+   values but with environment name `testpypi`.
+
+3. In GitHub → Settings → Environments, create the `pypi` and `testpypi`
+   environments. Adding required reviewers to `pypi` is recommended: a PyPI
+   version can never be reused or re-uploaded, so a human approval gate is the
+   last chance to catch a bad build.
+
+## Cutting a release
+
+1. Bump the version in **both** places — they are asserted equal by
+   `tests/test_exceptions.py::test_version_matches_pyproject`:
+
+   ```bash
+   poetry version <new-version>          # pyproject.toml
+   # then edit skyportalai/_version.py to match
+   ```
+
+2. Verify locally:
+
+   ```bash
+   poetry check --strict
+   poetry run pytest
+   poetry run ruff check .
+   poetry build
+   ```
+
+3. Merge to `main`.
+
+4. *(Optional but recommended for a first release.)* Actions → **Publish** →
+   Run workflow, to push to TestPyPI, then confirm the install:
+
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ skyportalai
+   ```
+
+   The extra index is needed because TestPyPI does not mirror the runtime
+   dependencies.
+
+5. Publish a GitHub Release tagged `vX.Y.Z`. The workflow refuses to build if
+   the tag does not match the version in `pyproject.toml`. On success the
+   release lands at <https://pypi.org/project/skyportalai/>.
+
+## Notes
+
+- The workflow attaches [PEP 740](https://peps.python.org/pep-0740/) digital
+  attestations automatically; no extra configuration is required.
+- The distribution is named `skyportalai`, but it also installs a top-level
+  `skyportal` import package. An unrelated astronomy project owns the
+  `skyportal` *distribution* name on PyPI, so installing both in one
+  environment would collide on that import name.


### PR DESCRIPTION
## Change type

- [ ] 🆕 New or changed CLI command / flag
- [ ] 🔄 Behavior change (observable difference for users)
- [x] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [x] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

`skyportalai` has never been published to PyPI, so the only documented way to
install it is `git clone`. This adds the release pipeline.

`.github/workflows/publish.yml` uploads the package using PyPI
[Trusted Publishing](https://docs.pypi.org/trusted-publishers/): PyPI verifies a
short-lived OIDC token minted by GitHub Actions, so no long-lived API token is
stored in this repository and there is nothing to rotate. One build job feeds
two publish jobs:

| Trigger | Index | Environment |
| --- | --- | --- |
| GitHub Release published | pypi.org | `pypi` |
| `workflow_dispatch` (manual) | test.pypi.org | `testpypi` |

The TestPyPI path exists so a first release can be rehearsed end to end. It sets
`skip-existing` so re-running a dry run for an already-uploaded version is not an
error.

**Guardrail:** the build job fails when the release tag and the version in
`pyproject.toml` disagree. A PyPI version can never be reused or re-uploaded, so
a mistyped tag would permanently burn that version number. Version consistency
between `pyproject.toml` and `skyportalai/_version.py` is already asserted by
`tests/test_exceptions.py::test_version_matches_pyproject`.

Action SHAs are pinned with version comments, matching the convention in
`ci.yml`. The existing `github-actions` Dependabot ecosystem already covers
them.

### README link fixes

PyPI does not resolve relative paths in the long description, so on the project
page the demo GIF would not have rendered and six links (`LICENSE`,
`docs/agent.md`, `CONTRIBUTING.md`, `SECURITY.md`) would have 404'd. All are now
absolute GitHub URLs, which still resolve correctly when viewed on GitHub. The
README also gains `pip install skyportalai` and PyPI version / Python version
badges.

### docs/RELEASING.md

The runbook: the one-time pending-publisher values for each index, and the steps
to cut a release.

---

## Security callout

This PR is about publishing credentials, so it is worth being explicit.

**No credential is introduced by this PR.** That is the reason for choosing
Trusted Publishing over the alternative of storing a `PYPI_API_TOKEN` in repo
secrets. The workflow authenticates with an ephemeral OIDC token that GitHub
mints per run and PyPI validates against a publisher identity it has on file
(repository, workflow filename, and environment). There is no static secret to
leak, and no rotation burden.

Risk controls in the workflow:

- `permissions: contents: read` at the top level; `id-token: write` is granted
  only to the two publish jobs that need it, never to the build job.
- Publishing is gated behind the `pypi` / `testpypi` GitHub environments, so
  approval rules and branch restrictions can be enforced outside this file.
  Required reviewers on `pypi` are recommended in `docs/RELEASING.md`, since a
  PyPI upload is irreversible.
- `persist-credentials: false` on checkout, matching `ci.yml`.
- Every third-party action is pinned to a full commit SHA rather than a
  floating tag.
- The publish jobs only download the build artifact; they never check out the
  repository or execute repository code.

**Follow-up required before this works** (cannot be done from a PR — needs an
account that owns the project on each index): register `skyportalai` as a
*pending publisher* on PyPI and TestPyPI, and create the two GitHub
environments. Exact values are in `docs/RELEASING.md`.

---

## Validation

- [x] Tests added or updated where behavior changed — no code change; existing
      version-consistency test already covers the invariant the workflow enforces
- [x] `poetry run pytest` passes — 463 passed
- [x] `poetry run ruff check .` passes
- [x] Public API/configuration changes are documented — `docs/RELEASING.md`, README
- [x] No credentials or private run data are included

Also verified locally:

- `poetry check --strict` → All set!
- `poetry build` → clean sdist + wheel
- `twine check dist/*` → PASSED on both artifacts
- Wheel installed into a clean venv: `import skyportalai` works and all three
  console scripts (`skyportal`, `skyportalai`, `skyportal-agent`) are present
- `skyportalai` confirmed available on PyPI (HTTP 404)

> [!NOTE]
> The distribution name `skyportalai` is free, but the bare `skyportal`
> distribution name belongs to an unrelated astronomy project. This package
> installs a top-level `skyportal` **import** module, so installing both into one
> environment would collide on that import name. Noted in `docs/RELEASING.md`;
> no action needed unless we want to rename the module.

## Related issue

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated publishing to TestPyPI and PyPI through the release workflow.
  - Added package installation instructions and PyPI/Python version badges to the README.

- **Documentation**
  - Added release documentation covering version updates, verification, trusted publishing setup, and release procedures.
  - Updated documentation links for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->