### PR TITLE
Harden the release runbook

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,9 +31,19 @@ the project is created on the first successful upload.
    values but with environment name `testpypi`.
 
 3. In GitHub → Settings → Environments, create the `pypi` and `testpypi`
-   environments. Adding required reviewers to `pypi` is recommended: a PyPI
-   version can never be reused or re-uploaded, so a human approval gate is the
-   last chance to catch a bad build.
+   environments, and add **required reviewers** to `pypi`.
+
+   Do not skip this. If a workflow references an environment that does not
+   exist, GitHub creates it automatically *with no protection rules* — so the
+   first release would publish with no approval gate at all. A PyPI version can
+   never be reused or re-uploaded, so this human approval is the last chance to
+   catch a bad build.
+
+4. Restrict who can create `v*` tags, so that cutting a release and approving
+   one stay separate privileges. Either add a
+   [tag protection rule](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/configuring-tag-protection-rules)
+   for `v*`, or limit the `pypi` environment's deployment branches and tags to
+   the `v*` pattern.
 
 ## Cutting a release
 
@@ -60,16 +70,28 @@ the project is created on the first successful upload.
    Run workflow, to push to TestPyPI, then confirm the install:
 
    ```bash
-   pip install --index-url https://test.pypi.org/simple/ \
+   python3 -m venv /tmp/skyportal-check
+   /tmp/skyportal-check/bin/pip install \
+     --index-url https://test.pypi.org/simple/ \
      --extra-index-url https://pypi.org/simple/ skyportalai
+   /tmp/skyportal-check/bin/skyportal --help
    ```
 
    The extra index is needed because TestPyPI does not mirror the runtime
-   dependencies.
+   dependencies. The virtualenv is needed because Debian, Ubuntu, Fedora and
+   Homebrew mark the system Python as externally managed
+   ([PEP 668](https://peps.python.org/pep-0668/)), so a bare `pip install`
+   fails with `error: externally-managed-environment`.
 
-5. Publish a GitHub Release tagged `vX.Y.Z`. The workflow refuses to build if
-   the tag does not match the version in `pyproject.toml`. On success the
-   release lands at <https://pypi.org/project/skyportalai/>.
+5. Publish a GitHub Release tagged `vX.Y.Z`, **created from `main`**. The
+   workflow refuses to build if the tag does not match the version in
+   `pyproject.toml`. On success the release lands at
+   <https://pypi.org/project/skyportalai/>.
+
+   > On a `release` event, GitHub runs the workflow as it exists *in the commit
+   > the tag points at*, not as it exists on `main`. Re-publishing an old
+   > release therefore re-runs that old release's workflow. Always tag from
+   > current `main`.
 
 ## Notes
 
@@ -79,3 +101,21 @@ the project is created on the first successful upload.
   `skyportal` import package. An unrelated astronomy project owns the
   `skyportal` *distribution* name on PyPI, so installing both in one
   environment would collide on that import name.
+- A "pending" publisher does not reserve the project name. If someone else
+  registers `skyportalai` before the first successful upload, the pending
+  publisher is invalidated. The name is only held once a release actually
+  lands; a TestPyPI run does not reserve it.
+
+## Prior art
+
+An earlier attempt to publish (release `v0.1.0`, 2026-07-17) failed, and the
+workflow was removed in a89e154 rather than retried. The workflow was not at
+fault: it presented correct OIDC claims (`repository: SkyportalAi/skyportalai`,
+`workflow_ref: .../publish.yml@refs/tags/v0.1.0`, `environment: pypi`) and PyPI
+rejected them only because no trusted publisher had been registered for the
+project. Nothing was ever uploaded to PyPI or TestPyPI.
+
+The lesson is that step 1 of the one-time setup is the step that actually
+matters — the workflow cannot succeed until PyPI has a matching publisher on
+file. Note also that the `v0.1.0` tag predates the current workflow, so a new
+release must be tagged from current `main`.


### PR DESCRIPTION
## Change type

- [ ] 🆕 New or changed CLI command / flag
- [ ] 🔄 Behavior change (observable difference for users)
- [x] 🔒 Security-sensitive change (auth, credentials, kubeconfig, secrets)
- [x] 🔧 Pure refactor / chore (no behavior change)

---

## Summary

Documentation-only follow-up to #52. Closes out the review comment there and
records what we learned attempting the first release.

**Approval gate is now required, not recommended.** GitHub auto-creates an
environment that a workflow references *with no protection rules*, so leaving
reviewers optional meant the first release would publish with no gate at all.
Verified: neither `pypi` nor `testpypi` currently exists (`GET
/repos/SkyportalAi/skyportalai/environments/pypi` → 404). Also adds
tag-protection guidance so cutting a release and approving one stay separate
privileges.

**Releases must be tagged from current `main`.** On a `release` event GitHub
runs the workflow from the commit the tag points at, not from `main`. The
existing `v0.1.0` tag predates the current workflow, so re-publishing that
release would silently run the old, deleted workflow. This is not hypothetical —
it is what the historical run did.

**TestPyPI verification needs a virtualenv.** Debian, Ubuntu, Fedora and
Homebrew mark the system Python as externally managed
([PEP 668](https://peps.python.org/pep-0668/)), so the documented
`pip install` fails with `error: externally-managed-environment`.

**Pending publishers do not reserve the name**, per PyPI's docs — worth stating
so nobody assumes configuring one holds `skyportalai`.

### Prior art

Release `v0.1.0` (2026-07-17) failed and the workflow was removed in a89e154
rather than retried. The workflow was not at fault — it presented correct OIDC
claims and PyPI rejected them only because no trusted publisher was registered:

```
workflow_ref: SkyportalAi/skyportalai/.github/workflows/publish.yml@refs/tags/v0.1.0
environment:  pypi
invalid-publisher: valid token, but no corresponding publisher
```

Nothing was ever uploaded to PyPI or TestPyPI. Recorded in the runbook so the
next person does not re-diagnose it, and so it is clear the remaining work is
entirely on the PyPI side.

---

## Security callout

Docs only; no workflow or code changes, and no credential is introduced.

The net effect is to tighten the release path rather than loosen it: an approval
gate on `pypi` moves from optional to required, and tag creation becomes a
restricted privilege. Both address the review finding on #52 that
`publish-pypi` runs for every published Release with `id-token: write` and no
human checkpoint.

---

## Validation

- [x] Tests added or updated where behavior changed — N/A, documentation only
- [x] `poetry run pytest` passes — unchanged by this PR
- [x] `poetry run ruff check .` passes
- [x] Public API/configuration changes are documented — this PR *is* the docs
- [x] No credentials or private run data are included

The OIDC claims quoted above are from a public failed Actions log and contain no
secrets — they are public repository identifiers.

## Related issue

Follow-up to #52
