### PR TITLE
fix(cli): name the target instance before prompting for a secret (0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project are documented here. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `skyportalai login` and `skyportalai github-token set` now name the instance
+  they are connecting to before prompting for a secret, and warn when that
+  target is a loopback address, naming both `config.yaml` and
+  `skyportalai configure` in the warning. A `base_url` saved during local
+  development outranked the shipped default with nothing on screen to show
+  it, so a key could be created against the wrong instance (or against a page
+  that never loaded).
+
 ## 0.2.1
 
 ### Fixed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,6 +42,10 @@ An older pip fails with `Directory cannot be installed in editable mode`, and a
 
 The default application URL is `https://app.skyportal.ai`. Run `skyportalai login`, create an account API key on the browser page, and paste the `sk_` value into the hidden prompt.
 
+`login` prints the instance it is connecting to before prompting, so check that
+line if you are not sure which deployment the key will belong to. A saved
+`base_url` outranks the default, and `login` warns when it is a loopback address.
+
 To use an existing key non-persistently:
 
 ```bash
@@ -114,6 +118,25 @@ a manual install, create the venv with `python3.11` or newer explicitly.
 - Run `skyportalai login` and create a fresh `sk_` API key.
 - Ensure the key is active and not expired or revoked.
 - An `agt_` token cannot authorize account or chat operations.
+
+### Login points at localhost
+
+`login` echoes `Connecting to ...` and warns when the target is a local address:
+
+```
+Connecting to http://localhost:8000
+Warning: base_url is a local address (http://localhost:8000) from
+/home/you/.skyportalai/config.yaml — run skyportalai configure to change it.
+```
+
+That URL came from `config.yaml`, usually written during earlier local
+development. A key created there belongs to the local instance, and the key page
+will not load at all with no local server running. Point the CLI back at the
+deployment you want before pasting a key:
+
+```bash
+skyportalai configure --portal-url https://app.skyportal.ai
+```
 
 ### Browser login lands on another page
 

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -56,6 +56,26 @@ def _redacted(base_url: str) -> str:
     return shown.removeprefix("//") if schemeless else shown
 
 
+def _is_loopback(host: str) -> bool:
+    """Whether ``host`` names the local machine."""
+    return host in _LOOPBACK_HOSTS or host.endswith(".localhost")
+
+
+def describe_base_url(base_url: str) -> tuple[str, bool]:
+    """Return ``base_url`` in a form safe to display, and whether it is loopback.
+
+    A caller that names its target before prompting for a credential needs both
+    facts, and neither should be re-derived here: the redaction keeps embedded
+    userinfo out of terminals and logs, and the loopback test has to stay
+    identical to the one :func:`_validate_base_url` enforces.
+    """
+    try:
+        host = (urlsplit(base_url).hostname or "").lower()
+    except ValueError:
+        host = ""
+    return _redacted(base_url), _is_loopback(host)
+
+
 def _validate_base_url(base_url: str) -> None:
     """Validate an API root before a Bearer credential can be sent to it.
 
@@ -87,7 +107,7 @@ def _validate_base_url(base_url: str) -> None:
             f"Invalid base_url {shown!r}: query strings and fragments are not allowed."
         )
 
-    loopback = host in _LOOPBACK_HOSTS or host.endswith(".localhost")
+    loopback = _is_loopback(host)
     if parts.scheme != "https" and not loopback:
         if _env.get("SKYPORTALAI_ALLOW_INSECURE") == "1":
             warnings.warn(

--- a/skyportalai/cli/shell_commands.py
+++ b/skyportalai/cli/shell_commands.py
@@ -16,7 +16,7 @@ from rich.markdown import Markdown
 from rich.table import Table
 
 from skyportalai import _env
-from skyportalai._client import DEFAULT_BASE_URL
+from skyportalai._client import DEFAULT_BASE_URL, describe_base_url
 from skyportalai.shell import (
     ConfigManager,
     CredentialStore,
@@ -37,6 +37,32 @@ err_console = Console(stderr=True)
 def _portal_client() -> SkyportalClient:
     portal = ConfigManager.load_config().portal
     return SkyportalClient(portal.base_url, portal.request_timeout)
+
+
+def _base_url_is_configured(base_url: str) -> bool:
+    """Whether ``base_url`` came from the config file rather than the default."""
+    return base_url != PortalConfig().base_url
+
+
+def _announce_target() -> None:
+    """Name the instance a secret is about to be sent to, before prompting.
+
+    ``config.yaml`` outranks the shipped default forever, with no expiry, so
+    the instance that issues (and scopes) a credential is otherwise invisible
+    at the one moment it decides where that credential goes. A loopback target
+    gets an explicit warning naming the file: it is never a real account, and
+    with no local server running the key page does not even load.
+    """
+    portal = ConfigManager.load_config().portal
+    shown, loopback = describe_base_url(portal.base_url)
+    console.print(f"Connecting to [bold]{shown}[/bold]")
+    if not loopback:
+        return
+    origin = f" from {ConfigManager.get_config_path()}" if _base_url_is_configured(portal.base_url) else ""
+    console.print(
+        f"[yellow]Warning:[/yellow] base_url is a local address ({shown}){origin} — "
+        "run [bold]skyportalai configure[/bold] to change it."
+    )
 
 
 def _items(payload: Any) -> list[dict[str, Any]]:
@@ -94,6 +120,7 @@ def login(
     enter_token: Annotated[bool, typer.Option("--token", help="Paste an existing API key")] = False,
 ) -> None:
     """Create or paste an account API key and connect the CLI."""
+    _announce_target()
     client = _portal_client()
     try:
         if not enter_token:
@@ -214,6 +241,7 @@ def github_token_set(
     ] = None,
 ) -> None:
     """Save a GitHub PAT (prompts for the token without echoing it)."""
+    _announce_target()
     try:
         pat = typer.prompt("GitHub Personal Access Token", hide_input=True)
         result = _portal_client().save_github_token(pat.strip(), repo=repo)

--- a/tests/test_cli_login_target.py
+++ b/tests/test_cli_login_target.py
@@ -1,0 +1,96 @@
+"""`login` and `github-token set` name the instance before prompting.
+
+A persistent ``config.yaml`` outranks the shipped default forever, so without
+these lines the instance that issues (and scopes) the credential is invisible
+at the moment the prompt appears.
+"""
+
+from __future__ import annotations
+
+import yaml
+from typer.testing import CliRunner
+
+from skyportalai.cli.main import app
+
+runner = CliRunner()
+
+
+class FakeClient:
+    """Enough of ``SkyportalClient`` for the ``--token`` and PAT paths."""
+
+    def __init__(self):
+        self.saved: list[str] = []
+
+    def set_access_token(self, token):
+        self.saved.append(token)
+
+    def save_github_token(self, pat, repo=None):
+        self.saved.append(pat)
+        return {"success": True, "login": "octocat", "masked_token": "ghp_****abc"}
+
+
+def _isolated(monkeypatch, tmp_path, base_url=None):
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setenv("SKYPORTALAI_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("SKYPORTALAI_CREDENTIALS_PATH", str(tmp_path / "credentials.json"))
+    for name in ("SKYPORTALAI_API_KEY", "SKYPORTALAI_ACCESS_TOKEN", "SKYPORTALAI_BASE_URL", "SKYPORTALAI_URL"):
+        monkeypatch.delenv(name, raising=False)
+    # Keep rich from wrapping the file path mid-assertion.
+    monkeypatch.setenv("COLUMNS", "300")
+    if base_url is not None:
+        config_path.write_text(yaml.safe_dump({"portal": {"base_url": base_url, "request_timeout": 30}}))
+    client = FakeClient()
+    monkeypatch.setattr("skyportalai.cli.shell_commands._portal_client", lambda: client)
+    return config_path, client
+
+
+def test_login_names_the_default_target_without_warning(monkeypatch, tmp_path):
+    _isolated(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["login", "--token"], input="sk-test\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Connecting to https://app.skyportal.ai" in result.output
+    assert "Warning" not in result.output
+
+
+def test_login_warns_that_a_loopback_target_came_from_the_config_file(monkeypatch, tmp_path):
+    config_path, _ = _isolated(monkeypatch, tmp_path, base_url="http://localhost:8000")
+
+    result = runner.invoke(app, ["login", "--token"], input="sk-test\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Connecting to http://localhost:8000" in result.output
+    assert "base_url is a local address (http://localhost:8000)" in result.output
+    assert str(config_path) in result.output
+    assert "skyportalai configure" in result.output
+
+
+def test_login_warns_for_any_loopback_spelling(monkeypatch, tmp_path):
+    _isolated(monkeypatch, tmp_path, base_url="http://app.localhost:8000")
+
+    result = runner.invoke(app, ["login", "--token"], input="sk-test\n")
+
+    assert result.exit_code == 0, result.output
+    assert "base_url is a local address" in result.output
+
+
+def test_login_never_echoes_userinfo_from_the_configured_url(monkeypatch, tmp_path):
+    _isolated(monkeypatch, tmp_path, base_url="https://user:secret@portal.example")
+
+    result = runner.invoke(app, ["login", "--token"], input="sk-test\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Connecting to https://portal.example" in result.output
+    assert "secret" not in result.output
+
+
+def test_github_token_set_names_the_target_before_prompting(monkeypatch, tmp_path):
+    config_path, client = _isolated(monkeypatch, tmp_path, base_url="http://127.0.0.1:8000")
+
+    result = runner.invoke(app, ["github-token", "set"], input="ghp_test\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Connecting to http://127.0.0.1:8000" in result.output
+    assert str(config_path) in result.output
+    assert client.saved == ["ghp_test"]


### PR DESCRIPTION
Fixes SkyportalAi/skyportal-website#3398 (issue tracked on the website board; the code lives here).

## Problem

`skyportalai login` never said which instance it was sending you to. A `~/.skyportalai/config.yaml` written weeks earlier during local dev work outranks the shipped default forever:

```yaml
portal:
  base_url: http://localhost:8000
```

The key-page URL was the only clue, and it is easy to read past in an install-then-login flow. A key created on the wrong instance authenticates against the wrong instance and surfaces later as a confusing auth or empty-account error, far from the cause; a loopback target with no local server running means the page never loads at all, leaving the user at a hidden prompt for a key they cannot create.

## Change

`login` and `github-token set` — the two commands that prompt for a secret against a configured target — now echo the resolved target before prompting, and warn when it is loopback:

```
Connecting to http://localhost:8000
Warning: base_url is a local address (http://localhost:8000) from
/home/you/.skyportalai/config.yaml — run skyportalai configure to change it.
```

Against the default there is just the one line and no warning:

```
Connecting to https://app.skyportal.ai
```

- The loopback predicate and the userinfo redaction come from the new `_client.describe_base_url()` rather than being re-derived, so what is displayed stays consistent with what `_validate_base_url()` enforces (which now calls the same `_is_loopback` helper).
- The config path is named only when the file is what chose the URL, so the shipped default is never blamed for a file the user may not have.
- Userinfo in a configured `base_url` is stripped before printing, so a target URL cannot leak a password into a terminal or CI log.

`docs/deployment.md` gains a troubleshooting entry for the loopback case.

## Tests

`tests/test_cli_login_target.py` covers the default target (no warning), a loopback target from the config file (warning names the path and `skyportalai configure`), the `.localhost` and `127.0.0.1` spellings, userinfo redaction, and `github-token set`. Full suite: 536 passed; `ruff check` clean.

## Release

Cut as **0.2.2**: version bumped in `pyproject.toml` and `skyportalai/_version.py` (asserted equal by `tests/test_exceptions.py::test_version_matches_pyproject`), and the CHANGELOG section dated. Verified with `poetry check --strict`, `pytest`, `ruff check .` and `poetry build` (`skyportalai-0.2.2`). Tag `v0.2.2` is cut from `main` after this merges.