### PR TITLE
fix(cli): let logout clear credentials it cannot validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,16 @@ All notable changes to this project are documented here. This project follows
   reports it. An unparseable credential file is treated the same way — deleting
   a file should not require the file to be valid.
 - Both deployment-mismatch messages (the public CLI and the interactive shell)
-  now name the two URLs that disagree, the credential file, and the command
-  that clears it.
+  now name the two URLs that disagree, the credential file, and the way to keep
+  the credential instead — which depends on whether `--base-url`, an
+  environment variable or `config.yaml` selected the target, since the first
+  two outrank the file and advice to edit it would be a dead end.
+- **`https://skyportal.ai` and `https://app.skyportal.ai` are no longer treated
+  as two deployments.** The shell client normalizes the marketing host to the
+  app host before saving a credential, so configuring the marketing spelling
+  produced a permanent conflict that `logout` and `login` only recreated. The
+  normalization now lives in one place (`_client.normalize_base_url`) and both
+  comparisons use it.
 - `skyportalai login` and `skyportalai github-token set` now name the instance
   they are connecting to before prompting for a secret, and warn when that
   target is a loopback address, naming both `config.yaml` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project follows
 
 ### Fixed
 
+- **`skyportalai logout` is reachable again when the stored credential points
+  at another deployment** — the state logout exists to clean up. Credential
+  resolution runs above every command and used to abort with a traceback on a
+  deployment mismatch, so the CLI stayed wedged until
+  `~/.skyportalai/credentials.json` was deleted by hand. Resolution now records
+  the problem instead of raising: `logout` works, commands that need a
+  credential fail with a normal `Error:` line, and `skyportalai config show`
+  reports it. An unparseable credential file is treated the same way — deleting
+  a file should not require the file to be valid.
+- Both deployment-mismatch messages (the public CLI and the interactive shell)
+  now name the two URLs that disagree, the credential file, and the command
+  that clears it.
 - `skyportalai login` and `skyportalai github-token set` now name the instance
   they are connecting to before prompting for a secret, and warn when that
   target is a loopback address, naming both `config.yaml` and

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,12 +147,15 @@ key is only valid on the instance that issued it:
 Error: Stored credentials belong to another SkyPortal deployment
 (http://localhost:8000), but the selected base URL is https://app.skyportal.ai.
 Run 'skyportalai logout' to clear them (/home/you/.skyportalai/credentials.json),
-or point the CLI back with 'skyportalai config set --base-url'.
+or keep them by running 'skyportalai config set --base-url http://localhost:8000'.
 ```
 
 Either clear the key with `skyportalai logout` and run `skyportalai login`
-against the instance you want, or put the base URL back. `skyportalai config
-show` reports the same conflict without needing a working credential.
+against the instance you want, or put the base URL back — the message names the
+setting that actually chose the target, which is `--base-url` or
+`SKYPORTALAI_BASE_URL` when either is in play, because both outrank
+`config.yaml`. `skyportalai config show` reports the same conflict without
+needing a working credential.
 
 ### Browser login lands on another page
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -138,6 +138,22 @@ deployment you want before pasting a key:
 skyportalai configure --portal-url https://app.skyportal.ai
 ```
 
+### Stored credentials belong to another deployment
+
+Repointing the CLI at a different instance leaves the saved key behind, and a
+key is only valid on the instance that issued it:
+
+```
+Error: Stored credentials belong to another SkyPortal deployment
+(http://localhost:8000), but the selected base URL is https://app.skyportal.ai.
+Run 'skyportalai logout' to clear them (/home/you/.skyportalai/credentials.json),
+or point the CLI back with 'skyportalai config set --base-url'.
+```
+
+Either clear the key with `skyportalai logout` and run `skyportalai login`
+against the instance you want, or put the base URL back. `skyportalai config
+show` reports the same conflict without needing a working credential.
+
 ### Browser login lands on another page
 
 Return to the `/keys/` URL printed in the terminal. The product website also preserves the key-page return path across its production login exchange.

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -24,6 +24,9 @@ from .types import PermissionMode, User
 
 DEFAULT_BASE_URL = "https://app.skyportal.ai"
 
+#: The marketing site is the same deployment as the app host but serves no API.
+MARKETING_BASE_URL = "https://skyportal.ai"
+
 #: Hosts allowed to use plain ``http://`` (local development only).
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 _PERMISSION_MODES = frozenset({"ask", "autoapprove"})
@@ -54,6 +57,19 @@ def _redacted(base_url: str) -> str:
         netloc = f"{netloc}:{port}"
     shown = urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
     return shown.removeprefix("//") if schemeless else shown
+
+
+def normalize_base_url(base_url: str) -> str:
+    """Canonical form of a base URL, for storing, comparing and requesting.
+
+    Two spellings of the production deployment reach the same place, and the
+    marketing host has no API, so anything comparing base URLs has to agree on
+    one of them. Kept here rather than beside a caller because the shell client
+    and the public CLI both compare stored against selected URLs, and a second
+    copy would let them disagree about whether two URLs name one deployment.
+    """
+    trimmed = base_url.rstrip("/")
+    return DEFAULT_BASE_URL if trimmed == MARKETING_BASE_URL else trimmed
 
 
 def _is_loopback(host: str) -> bool:

--- a/skyportalai/cli/config.py
+++ b/skyportalai/cli/config.py
@@ -11,8 +11,10 @@ from typing import Any
 import yaml
 
 from skyportalai import _env
-from skyportalai._client import DEFAULT_BASE_URL
+from skyportalai._client import DEFAULT_BASE_URL, normalize_base_url
 from skyportalai._exceptions import SkyportalError
+
+_FLAG_ORIGIN = "--base-url"
 
 
 @dataclass(frozen=True)
@@ -50,16 +52,12 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
     if not isinstance(portal, dict):
         raise SkyportalError(f"Invalid SkyPortal configuration in {config_path}: 'portal' must be a mapping.")
 
-    configured_url = portal.get("base_url")
     stored_url = credentials.get("base_url")
-    effective_url = (
-        base_url
-        or _env.get("SKYPORTALAI_BASE_URL")
-        or _env.get("SKYPORTALAI_URL")
-        or (str(configured_url) if configured_url else None)
-        or (str(stored_url) if stored_url else None)
-        or DEFAULT_BASE_URL
-    ).rstrip("/")
+    effective_url, url_origin = _select_base_url(
+        flag=base_url,
+        configured=portal.get("base_url"),
+        stored=stored_url,
+    )
 
     timeout_value = portal.get("request_timeout", 30.0)
     try:
@@ -76,12 +74,16 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
     if not api_key:
         api_key, source = _env.lookup("SKYPORTALAI_API_KEY")
     if not api_key and credentials.get("access_token"):
-        if stored_url and str(stored_url).rstrip("/") != effective_url:
+        # Normalized on both sides: the shell client rewrites the marketing host
+        # to the app host before saving, so a raw comparison reports a conflict
+        # between two spellings of one deployment that logout cannot resolve.
+        stored_normalized = normalize_base_url(str(stored_url)) if stored_url else None
+        if stored_normalized and stored_normalized != effective_url:
             credential_conflict = (
                 f"Stored credentials belong to another SkyPortal deployment "
-                f"({str(stored_url).rstrip('/')}), but the selected base URL is {effective_url}. "
+                f"({stored_normalized}), but the selected base URL is {effective_url}. "
                 f"Run 'skyportalai logout' to clear them ({credentials_path}), "
-                f"or point the CLI back with 'skyportalai config set --base-url'."
+                f"or keep them by {_keep_credentials_advice(url_origin, stored_normalized)}."
             )
         else:
             api_key = str(credentials["access_token"])
@@ -96,6 +98,36 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
         credentials_path=credentials_path,
         credential_conflict=credential_conflict,
     )
+
+
+def _select_base_url(*, flag: str | None, configured: Any, stored: Any) -> tuple[str, str | None]:
+    """The effective base URL, and the flag or variable that selected it.
+
+    The origin is not decoration: ``--base-url`` and the environment both
+    outrank ``config.yaml``, so advice to run ``config set --base-url`` is a
+    dead end when one of them is what chose the URL.
+    """
+    if flag:
+        return normalize_base_url(flag), _FLAG_ORIGIN
+    env_url, env_name = _env.lookup("SKYPORTALAI_BASE_URL")
+    if not env_url:
+        env_url, env_name = _env.lookup("SKYPORTALAI_URL")
+    if env_url:
+        return normalize_base_url(env_url), env_name
+    if configured:
+        return normalize_base_url(str(configured)), None
+    if stored:
+        return normalize_base_url(str(stored)), None
+    return DEFAULT_BASE_URL, None
+
+
+def _keep_credentials_advice(url_origin: str | None, stored_url: str) -> str:
+    """How to make the selected URL match the stored credential."""
+    if url_origin == _FLAG_ORIGIN:
+        return f"dropping {_FLAG_ORIGIN}"
+    if url_origin:
+        return f"unsetting {url_origin}"
+    return f"running 'skyportalai config set --base-url {stored_url}'"
 
 
 def save_connection_config(*, base_url: str | None, timeout: float | None) -> Path:
@@ -123,11 +155,27 @@ def save_connection_config(*, base_url: str | None, timeout: float | None) -> Pa
 
 
 def _read_credentials(path: Path) -> tuple[dict[str, Any], str | None]:
-    """Read the credential file, reporting rather than raising when it is unusable."""
+    """Read the credential file, reporting rather than raising when it cannot be used.
+
+    Content failures and access failures get different advice on purpose: an
+    unparseable file is worth deleting, but a permission error or a transient
+    read failure on a perfectly good credential is not.
+    """
+    if not path.exists():
+        return {}, None
     try:
-        return _read_mapping(path, "credentials", json.load), None
-    except SkyportalError as exc:
-        return {}, f"{exc} Run 'skyportalai logout' to remove the file."
+        with path.open() as source:
+            value = json.load(source) or {}
+    except OSError as exc:
+        return {}, f"Could not read SkyPortal credentials from {path}: {exc}. Check the file's permissions."
+    except ValueError as exc:
+        return {}, f"Invalid SkyPortal credentials in {path}: {exc}. Run 'skyportalai logout' to remove the file."
+    if not isinstance(value, dict):
+        return {}, (
+            f"Invalid SkyPortal credentials in {path}: expected a mapping. "
+            "Run 'skyportalai logout' to remove the file."
+        )
+    return value, None
 
 
 def _read_mapping(path: Path, label: str, loader: Any) -> dict[str, Any]:

--- a/skyportalai/cli/config.py
+++ b/skyportalai/cli/config.py
@@ -25,6 +25,8 @@ class CLISettings:
     timeout: float
     config_path: Path
     credentials_path: Path
+    #: Why a stored credential could not be used, if there was one.
+    credential_conflict: str | None = None
 
 
 def get_config_path() -> Path:
@@ -40,7 +42,10 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
     config_path = get_config_path()
     credentials_path = get_credentials_path()
     config = _read_mapping(config_path, "configuration", yaml.safe_load)
-    credentials = _read_mapping(credentials_path, "credentials", json.load)
+    # Resolution must not die on the credential file: `skyportalai logout`
+    # exists to remove exactly the file that cannot be used, and it runs
+    # through this same resolution. Record the reason instead of raising.
+    credentials, credential_conflict = _read_credentials(credentials_path)
     portal = config.get("portal", {})
     if not isinstance(portal, dict):
         raise SkyportalError(f"Invalid SkyPortal configuration in {config_path}: 'portal' must be a mapping.")
@@ -72,12 +77,15 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
         api_key, source = _env.lookup("SKYPORTALAI_API_KEY")
     if not api_key and credentials.get("access_token"):
         if stored_url and str(stored_url).rstrip("/") != effective_url:
-            raise SkyportalError(
-                "Stored credentials belong to another SkyPortal deployment. "
-                "Set SKYPORTALAI_API_KEY or update the selected base URL."
+            credential_conflict = (
+                f"Stored credentials belong to another SkyPortal deployment "
+                f"({str(stored_url).rstrip('/')}), but the selected base URL is {effective_url}. "
+                f"Run 'skyportalai logout' to clear them ({credentials_path}), "
+                f"or point the CLI back with 'skyportalai config set --base-url'."
             )
-        api_key = str(credentials["access_token"])
-        source = str(credentials_path)
+        else:
+            api_key = str(credentials["access_token"])
+            source = str(credentials_path)
 
     return CLISettings(
         api_key=api_key,
@@ -86,6 +94,7 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
         timeout=timeout,
         config_path=config_path,
         credentials_path=credentials_path,
+        credential_conflict=credential_conflict,
     )
 
 
@@ -111,6 +120,14 @@ def save_connection_config(*, base_url: str | None, timeout: float | None) -> Pa
         temporary.chmod(0o600)
     temporary.replace(path)
     return path
+
+
+def _read_credentials(path: Path) -> tuple[dict[str, Any], str | None]:
+    """Read the credential file, reporting rather than raising when it is unusable."""
+    try:
+        return _read_mapping(path, "credentials", json.load), None
+    except SkyportalError as exc:
+        return {}, f"{exc} Run 'skyportalai logout' to remove the file."
 
 
 def _read_mapping(path: Path, label: str, loader: Any) -> dict[str, Any]:

--- a/skyportalai/cli/context.py
+++ b/skyportalai/cli/context.py
@@ -24,9 +24,14 @@ class CLIContext:
 
     def client(self) -> Skyportal:
         if not self.settings.api_key:
+            # A stored-but-unusable credential is a different problem from having
+            # none, and only its own message names the way out.
             raise SkyportalError(
-                "No API key configured. Set SKYPORTALAI_API_KEY or run the "
-                "'skyportalai login' flow."
+                self.settings.credential_conflict
+                or (
+                    "No API key configured. Set SKYPORTALAI_API_KEY or run the "
+                    "'skyportalai login' flow."
+                )
             )
         return Skyportal(
             api_key=self.settings.api_key,

--- a/skyportalai/cli/main.py
+++ b/skyportalai/cli/main.py
@@ -69,7 +69,9 @@ def show_config(context: typer.Context) -> None:
         "authenticated": state.settings.api_key is not None,
         "api_key_source": state.settings.api_key_source,
         "config_path": state.settings.config_path,
+        "credential_conflict": state.settings.credential_conflict,
     }
+    conflict = f"\nCredential problem: {state.settings.credential_conflict}" if state.settings.credential_conflict else ""
     state.output.success(
         data,
         human=(
@@ -77,6 +79,7 @@ def show_config(context: typer.Context) -> None:
             f"Timeout: {state.settings.timeout:g}s\n"
             f"Credential: {state.settings.api_key_source or 'not configured'}\n"
             f"Config: {state.settings.config_path}"
+            f"{conflict}"
         ),
     )
 

--- a/skyportalai/cli/main.py
+++ b/skyportalai/cli/main.py
@@ -50,7 +50,14 @@ def root(
 ) -> None:
     """Resolve shared configuration before dispatching a command."""
     del version
-    settings = resolve_settings(base_url=base_url)
+    # Click fills --base-url from SKYPORTALAI_BASE_URL, so a value here does not
+    # mean the user typed a flag. Only a real flag is forwarded: resolution reads
+    # the environment itself, where it also honours the legacy SKYPORTAL_BASE_URL
+    # spelling and can say which setting selected the URL. The source is matched
+    # by name because the Context comes from Typer's vendored Click.
+    source = context.get_parameter_source("base_url")
+    typed_on_command_line = source is not None and source.name == "COMMANDLINE"
+    settings = resolve_settings(base_url=base_url if typed_on_command_line else None)
     context.obj = CLIContext(
         settings=settings,
         output=Output(json_mode=json_output, api_target=settings.base_url),

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -13,12 +13,12 @@ from urllib.parse import quote, urlencode
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from skyportalai import _env
-from skyportalai._client import _validate_base_url
+from skyportalai._client import DEFAULT_BASE_URL, MARKETING_BASE_URL, _validate_base_url, normalize_base_url
 from skyportalai._exceptions import SkyportalError
 from skyportalai._version import __version__
 
-PRODUCTION_MARKETING_URL = "https://skyportal.ai"
-PRODUCTION_APP_URL = "https://app.skyportal.ai"
+PRODUCTION_MARKETING_URL = MARKETING_BASE_URL
+PRODUCTION_APP_URL = DEFAULT_BASE_URL
 CLI_USER_AGENT = f"Skyportal-CLI/{__version__} (+https://app.skyportal.ai)"
 
 _BUSY_CHAT_STATUSES = {"processing", "uninitialized"}
@@ -131,12 +131,7 @@ class SkyportalClient:
     def __init__(self, base_url: str, timeout: int = 30):
         if timeout <= 0:
             raise PortalError("Request timeout must be greater than zero")
-        requested_base_url = base_url.rstrip("/")
-        self.base_url = (
-            PRODUCTION_APP_URL
-            if requested_base_url == PRODUCTION_MARKETING_URL
-            else requested_base_url
-        )
+        self.base_url = normalize_base_url(base_url)
         try:
             _validate_base_url(self.base_url)
         except SkyportalError as error:
@@ -662,12 +657,16 @@ class SkyportalClient:
             credentials = CredentialStore.load()
             if not credentials or not credentials.get("access_token"):
                 raise PortalError("Not connected. Run 'skyportalai login' first.")
-            if credentials.get("base_url") not in (None, self.base_url):
+            stored_url = credentials.get("base_url")
+            # self.base_url is already normalized, so the stored value has to be
+            # too: a credential saved as the marketing host names this same
+            # deployment, and re-running login would only save it again.
+            if stored_url is not None and normalize_base_url(str(stored_url)) != self.base_url:
                 raise PortalError(
                     "Stored credentials belong to another Skyportal deployment "
                     "({}), but this session targets {}. Run 'skyportalai logout' to "
                     "clear them ({}), or 'skyportalai login' to replace them.".format(
-                        credentials.get("base_url"), self.base_url, CredentialStore.get_path()
+                        stored_url, self.base_url, CredentialStore.get_path()
                     )
                 )
             token = str(credentials["access_token"])

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -664,8 +664,11 @@ class SkyportalClient:
                 raise PortalError("Not connected. Run 'skyportalai login' first.")
             if credentials.get("base_url") not in (None, self.base_url):
                 raise PortalError(
-                    "Stored credentials belong to another Skyportal deployment. "
-                    "Run 'skyportalai login' again."
+                    "Stored credentials belong to another Skyportal deployment "
+                    "({}), but this session targets {}. Run 'skyportalai logout' to "
+                    "clear them ({}), or 'skyportalai login' to replace them.".format(
+                        credentials.get("base_url"), self.base_url, CredentialStore.get_path()
+                    )
                 )
             token = str(credentials["access_token"])
         self._reject_agent_token(token)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -52,11 +52,15 @@ def test_credentials_are_scoped_to_the_selected_deployment(tmp_path, monkeypatch
     settings = resolve_settings()
 
     assert settings.api_key is None
-    assert "another SkyPortal deployment" in settings.credential_conflict
-    assert "https://one.example" in settings.credential_conflict
-    assert "https://two.example" in settings.credential_conflict
-    assert "skyportalai logout" in settings.credential_conflict
-    assert str(credentials) in settings.credential_conflict
+    # Compared whole rather than by substring: the message has to name both URLs,
+    # the file and the recovery command, and a containment check for a URL is the
+    # bug pattern CodeQL's py/incomplete-url-substring-sanitization looks for.
+    assert settings.credential_conflict == (
+        "Stored credentials belong to another SkyPortal deployment (https://one.example), "
+        "but the selected base URL is https://two.example. "
+        f"Run 'skyportalai logout' to clear them ({credentials}), "
+        "or point the CLI back with 'skyportalai config set --base-url'."
+    )
 
 
 def test_an_unreadable_credential_file_is_reported_not_raised(tmp_path):

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -49,8 +49,36 @@ def test_credentials_are_scoped_to_the_selected_deployment(tmp_path, monkeypatch
     credentials.write_text(json.dumps({"access_token": "sk-file", "base_url": "https://one.example"}))
     monkeypatch.setenv("SKYPORTALAI_BASE_URL", "https://two.example")
 
-    with pytest.raises(SkyportalError, match="another SkyPortal deployment"):
-        resolve_settings()
+    settings = resolve_settings()
+
+    assert settings.api_key is None
+    assert "another SkyPortal deployment" in settings.credential_conflict
+    assert "https://one.example" in settings.credential_conflict
+    assert "https://two.example" in settings.credential_conflict
+    assert "skyportalai logout" in settings.credential_conflict
+    assert str(credentials) in settings.credential_conflict
+
+
+def test_an_unreadable_credential_file_is_reported_not_raised(tmp_path):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text("{not json")
+
+    settings = resolve_settings()
+
+    assert settings.api_key is None
+    assert "skyportalai logout" in settings.credential_conflict
+    assert str(credentials) in settings.credential_conflict
+
+
+def test_a_matching_stored_credential_still_resolves(tmp_path, monkeypatch):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"access_token": "sk-file", "base_url": "https://one.example"}))
+    monkeypatch.setenv("SKYPORTALAI_BASE_URL", "https://one.example/")
+
+    settings = resolve_settings()
+
+    assert settings.api_key == "sk-file"
+    assert settings.credential_conflict is None
 
 
 def test_save_connection_config_is_private_and_legacy_compatible(tmp_path):

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -59,19 +59,77 @@ def test_credentials_are_scoped_to_the_selected_deployment(tmp_path, monkeypatch
         "Stored credentials belong to another SkyPortal deployment (https://one.example), "
         "but the selected base URL is https://two.example. "
         f"Run 'skyportalai logout' to clear them ({credentials}), "
-        "or point the CLI back with 'skyportalai config set --base-url'."
+        "or keep them by unsetting SKYPORTALAI_BASE_URL."
     )
 
 
-def test_an_unreadable_credential_file_is_reported_not_raised(tmp_path):
+def test_the_conflict_names_the_setting_that_actually_selected_the_url(tmp_path):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"access_token": "sk-file", "base_url": "https://one.example"}))
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"portal": {"base_url": "https://two.example"}}))
+
+    settings = resolve_settings()
+
+    assert settings.credential_conflict == (
+        "Stored credentials belong to another SkyPortal deployment (https://one.example), "
+        "but the selected base URL is https://two.example. "
+        f"Run 'skyportalai logout' to clear them ({credentials}), "
+        "or keep them by running 'skyportalai config set --base-url https://one.example'."
+    )
+
+
+def test_a_base_url_flag_is_not_fixable_by_editing_the_config(tmp_path):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"access_token": "sk-file", "base_url": "https://one.example"}))
+
+    settings = resolve_settings(base_url="https://two.example")
+
+    assert settings.credential_conflict == (
+        "Stored credentials belong to another SkyPortal deployment (https://one.example), "
+        "but the selected base URL is https://two.example. "
+        f"Run 'skyportalai logout' to clear them ({credentials}), "
+        "or keep them by dropping --base-url."
+    )
+
+
+def test_the_marketing_host_is_not_a_different_deployment(tmp_path):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"access_token": "sk-file", "base_url": "https://app.skyportal.ai"}))
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"portal": {"base_url": "https://skyportal.ai"}}))
+
+    settings = resolve_settings()
+
+    assert settings.credential_conflict is None
+    assert settings.api_key == "sk-file"
+    assert settings.base_url == "https://app.skyportal.ai"
+
+
+def test_an_unparseable_credential_file_is_reported_not_raised(tmp_path):
     credentials = tmp_path / "credentials.json"
     credentials.write_text("{not json")
 
     settings = resolve_settings()
 
     assert settings.api_key is None
-    assert "skyportalai logout" in settings.credential_conflict
-    assert str(credentials) in settings.credential_conflict
+    assert settings.credential_conflict.startswith(f"Invalid SkyPortal credentials in {credentials}:")
+    assert settings.credential_conflict.endswith("Run 'skyportalai logout' to remove the file.")
+
+
+@pytest.mark.skipif(os.name == "nt" or os.geteuid() == 0, reason="needs enforced file permissions")
+def test_an_unreadable_credential_file_is_not_advised_away(tmp_path):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"access_token": "sk-file"}))
+    credentials.chmod(0o000)
+
+    settings = resolve_settings()
+
+    assert settings.api_key is None
+    # Deleting a valid credential because the process could not open it would
+    # turn a permissions problem into a lost key.
+    assert "logout" not in settings.credential_conflict
+    assert settings.credential_conflict.endswith("Check the file's permissions.")
 
 
 def test_a_matching_stored_credential_still_resolves(tmp_path, monkeypatch):

--- a/tests/test_cli_logout_recovery.py
+++ b/tests/test_cli_logout_recovery.py
@@ -1,0 +1,88 @@
+"""`logout` stays reachable when the stored credential cannot be used.
+
+A credential saved against another deployment used to abort configuration
+resolution, which runs above every command — including the one whose whole job
+is to delete that credential. The CLI was wedged until the file was removed by
+hand.
+"""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+from typer.testing import CliRunner
+
+from skyportalai.cli.main import app
+
+runner = CliRunner()
+
+
+def _mismatched(monkeypatch, tmp_path, credential_body=None):
+    config_path = tmp_path / "config.yaml"
+    credentials_path = tmp_path / "credentials.json"
+    monkeypatch.setenv("SKYPORTALAI_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("SKYPORTALAI_CREDENTIALS_PATH", str(credentials_path))
+    for name in ("SKYPORTALAI_API_KEY", "SKYPORTALAI_ACCESS_TOKEN", "SKYPORTALAI_BASE_URL", "SKYPORTALAI_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("COLUMNS", "300")
+    config_path.write_text(yaml.safe_dump({"portal": {"base_url": "https://app.skyportal.ai"}}))
+    credentials_path.write_text(
+        credential_body
+        if credential_body is not None
+        else json.dumps({"access_token": "sk-local", "base_url": "http://localhost:8000"})
+    )
+    return credentials_path
+
+
+def test_logout_clears_credentials_from_another_deployment(monkeypatch, tmp_path):
+    credentials_path = _mismatched(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["logout"])
+
+    assert result.exit_code == 0, result.output
+    assert not credentials_path.exists()
+
+
+def test_logout_clears_a_credential_file_that_cannot_be_parsed(monkeypatch, tmp_path):
+    credentials_path = _mismatched(monkeypatch, tmp_path, credential_body="{not json")
+
+    result = runner.invoke(app, ["logout"])
+
+    assert result.exit_code == 0, result.output
+    assert not credentials_path.exists()
+
+
+def test_a_command_needing_the_credential_reports_the_conflict_without_a_traceback(monkeypatch, tmp_path):
+    credentials_path = _mismatched(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["chat", "status", "1"])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "another SkyPortal deployment" in result.output
+    assert "skyportalai logout" in result.output
+    assert str(credentials_path) in result.output
+    assert credentials_path.exists()
+
+
+def test_config_show_reports_the_conflict_as_data(monkeypatch, tmp_path):
+    credentials_path = _mismatched(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["--json", "config", "show"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["data"]["authenticated"] is False
+    assert "skyportalai logout" in payload["data"]["credential_conflict"]
+    assert "sk-local" not in result.stdout
+    assert credentials_path.exists()
+
+
+def test_config_show_stays_quiet_when_there_is_no_conflict(monkeypatch, tmp_path):
+    _mismatched(monkeypatch, tmp_path, credential_body=json.dumps({"access_token": "sk-live", "base_url": "https://app.skyportal.ai"}))
+
+    result = runner.invoke(app, ["config", "show"])
+
+    assert result.exit_code == 0, result.output
+    assert "Credential problem" not in result.output

--- a/tests/test_cli_logout_recovery.py
+++ b/tests/test_cli_logout_recovery.py
@@ -66,6 +66,28 @@ def test_a_command_needing_the_credential_reports_the_conflict_without_a_traceba
     assert credentials_path.exists()
 
 
+def test_the_advice_names_the_environment_variable_not_the_flag(monkeypatch, tmp_path):
+    # Click fills --base-url from SKYPORTALAI_BASE_URL, so the CLI must not blame
+    # a flag the user never typed; unsetting the variable is the only thing that
+    # would actually change the selected URL here.
+    _mismatched(monkeypatch, tmp_path)
+    monkeypatch.setenv("SKYPORTALAI_BASE_URL", "https://app.skyportal.ai")
+
+    result = runner.invoke(app, ["config", "show"])
+
+    assert result.exit_code == 0, result.output
+    assert "unsetting SKYPORTALAI_BASE_URL" in result.output
+
+
+def test_the_advice_names_the_flag_when_the_flag_was_typed(monkeypatch, tmp_path):
+    _mismatched(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["--base-url", "https://app.skyportal.ai", "config", "show"])
+
+    assert result.exit_code == 0, result.output
+    assert "dropping --base-url" in result.output
+
+
 def test_config_show_reports_the_conflict_as_data(monkeypatch, tmp_path):
     credentials_path = _mismatched(monkeypatch, tmp_path)
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -913,11 +913,12 @@ def test_credentials_from_another_deployment_name_the_way_out(credential_path):
     with pytest.raises(PortalError) as error:
         client.servers()
 
-    message = str(error.value)
-    assert "http://localhost:8000" in message
-    assert "https://app.skyportal.ai" in message
-    assert "skyportalai logout" in message
-    assert str(credential_path) in message
+    assert str(error.value) == (
+        "Stored credentials belong to another Skyportal deployment "
+        "(http://localhost:8000), but this session targets https://app.skyportal.ai. "
+        f"Run 'skyportalai logout' to clear them ({credential_path}), "
+        "or 'skyportalai login' to replace them."
+    )
 
 
 def test_raw_request_timeout_is_wrapped_as_portal_error(credential_path):

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -906,6 +906,20 @@ def test_missing_credentials_are_reported(credential_path):
         client.servers()
 
 
+def test_credentials_from_another_deployment_name_the_way_out(credential_path):
+    CredentialStore.save({"access_token": "sk_test", "base_url": "http://localhost:8000"})
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with pytest.raises(PortalError) as error:
+        client.servers()
+
+    message = str(error.value)
+    assert "http://localhost:8000" in message
+    assert "https://app.skyportal.ai" in message
+    assert "skyportalai logout" in message
+    assert str(credential_path) in message
+
+
 def test_raw_request_timeout_is_wrapped_as_portal_error(credential_path):
     CredentialStore.save(
         {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -921,6 +921,14 @@ def test_credentials_from_another_deployment_name_the_way_out(credential_path):
     )
 
 
+def test_marketing_host_credentials_are_not_another_deployment(credential_path):
+    CredentialStore.save({"access_token": "sk_test", "base_url": "https://skyportal.ai"})
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse({"servers": []})):
+        assert client.servers() == {"servers": []}
+
+
 def test_raw_request_timeout_is_wrapped_as_portal_error(credential_path):
     CredentialStore.save(
         {"access_token": "sk_test", "base_url": "https://app.skyportal.ai"}


### PR DESCRIPTION
Fixes SkyportalAi/skyportal-website#3402 (issue tracked on the website board; the code lives here).

## Problem

`skyportalai logout` could not run in the one state it exists to clean up. Stored credentials pointing at deployment A while the config points at deployment B produced an unhandled traceback — and left the credential in place:

```
skyportalai._exceptions.SkyportalError: Stored credentials belong to another
SkyPortal deployment. Set SKYPORTALAI_API_KEY or update the selected base URL.
```

`logout()` itself never validated anything; the raise came from `resolve_settings()` in the root callback (`skyportalai/cli/config.py`), which runs above every command. Every command failed the same way, so the CLI was wedged until `~/.skyportalai/credentials.json` was deleted by hand — which requires knowing that file exists.

## Change

Credential resolution now records why a stored credential is unusable (`CLISettings.credential_conflict`) instead of raising:

- **`logout` works** — it needs the path, not a validated token.
- **Commands that need a credential** get the CLI's normal error presentation instead of a stack trace, because the guard moved to the point of use (`CLIContext.client()`), where "no credential" and "a credential that cannot be used here" are two different messages:
  ```
  Error: Stored credentials belong to another SkyPortal deployment (http://localhost:8000),
  but the selected base URL is https://app.skyportal.ai. Run 'skyportalai logout' to clear
  them (/home/you/.skyportalai/credentials.json), or point the CLI back with
  'skyportalai config set --base-url'.
  ```
- **`config show`** reports the conflict as data (`credential_conflict` in JSON, a `Credential problem:` line in human output), so the diagnostic command works without a working credential.
- **An unparseable `credentials.json`** is treated the same way rather than raising: deleting a file should not require the file to be valid.
- The interactive shell had its **own copy** of the mismatch message (`shell/portal.py`); it now names the same things, so the two cannot drift into giving different advice.

I did not exempt `logout` by name in the root callback (the issue's suggestion 1). Moving the guard to the point of use fixes `logout` *and* every other command's traceback in one place, and it does not leave a command-name list in `root` for the next command that needs the same exemption.

## Notes

Verified by hand against the issue's repro (config → `https://app.skyportal.ai`, credentials → `http://localhost:8000`): `config show` and `chat status 1` print the message above and exit 1, `logout` exits 0 and removes the file.

Out of scope, noted for follow-up: the issue's second note — `--base-url` / `SKYPORTALAI_BASE_URL` are ignored by `login` and `github-token set`, which build their client from `ConfigManager.load_config()` alone. That is a separate ticket, as the issue says.

## Tests

New `tests/test_cli_logout_recovery.py` drives the real Typer app: `logout` with mismatched credentials, `logout` with an unparseable file, a credential-needing command reporting the conflict with no traceback, and `config show` with and without a conflict. `tests/test_cli_config.py` gains resolution-level cases (mismatch recorded, unreadable file recorded, matching credential still resolves) and its old "raises on mismatch" expectation is updated — that behaviour change is the fix. `tests/test_portal.py` covers the shell-side message. Full suite: 544 passed; `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of credentials from a different deployment or invalid credential files.
  * Logout remains available so unusable credentials can be cleared.
  * Credential-dependent commands now show clear recovery guidance without tracebacks.
  * Production URLs are recognized consistently across equivalent hostnames.

* **Enhancements**
  * Configuration inspection now reports credential conflicts in human-readable and JSON output.
  * Conflict messages include the affected deployments and recommended corrective actions.

* **Documentation**
  * Added troubleshooting guidance for resolving stored credentials tied to another deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->