### PR TITLE
feat(cli): connect the terminal from the browser instead of a pasted key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented here. This project follows
 
 ## Unreleased
 
+### Added
+
+- **`skyportalai login` connects the terminal by itself.** It starts an
+  authorization, prints a short code with the page to confirm it on, and waits;
+  approving in the browser hands the key back and the terminal finishes on its
+  own. No copying a key across windows, and nothing to paste. `/login` in the
+  interactive shell does the same. Falls back to the old key-page paste when the
+  deployment has no handshake endpoint, and `--token` (or `/token`) still pastes
+  a key deliberately.
+
 ### Fixed
 
 - `skyportalai login` and `skyportalai github-token set` now name the instance

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,7 +56,9 @@ The code is valid for ten minutes. Use `--no-browser` on a machine with no
 browser (the URL still prints, and can be opened anywhere you are signed in), or
 `skyportalai login --token` to paste an existing `sk_` key instead. A deployment
 that predates the handshake falls back to the key page automatically, and a
-proxy or WAF blocking the handshake does the same.
+proxy or WAF returning 403 does the same. Any other start failure — a 5xx from
+an unhealthy server, a connection error — stops with a message that names
+`skyportalai login --token` as the fallback.
 
 While it waits, a failed poll — a 502 from a proxy, a dropped connection — is
 retried with backoff until the code expires, so a network hiccup does not

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,7 +55,12 @@ https://app.skyportal.ai/cli/authorize/?code=BCDF-GHJK
 The code is valid for ten minutes. Use `--no-browser` on a machine with no
 browser (the URL still prints, and can be opened anywhere you are signed in), or
 `skyportalai login --token` to paste an existing `sk_` key instead. A deployment
-that predates the handshake falls back to the key page automatically.
+that predates the handshake falls back to the key page automatically, and a
+proxy or WAF blocking the handshake does the same.
+
+While it waits, a failed poll — a 502 from a proxy, a dropped connection — is
+retried with backoff until the code expires, so a network hiccup does not
+discard an approval that was already given.
 
 `login` prints the instance it is connecting to before prompting, so check that
 line if you are not sure which deployment the key will belong to. A saved

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,22 @@ An older pip fails with `Directory cannot be installed in editable mode`, and a
 
 ## Connect to production
 
-The default application URL is `https://app.skyportal.ai`. Run `skyportalai login`, create an account API key on the browser page, and paste the `sk_` value into the hidden prompt.
+The default application URL is `https://app.skyportal.ai`. Run `skyportalai login`:
+it prints a short code and opens the page that confirms it. Approve there and the
+terminal connects itself — no key to copy.
+
+```
+$ skyportalai login
+Connecting to https://app.skyportal.ai
+Confirm this code to connect: BCDF-GHJK
+https://app.skyportal.ai/cli/authorize/?code=BCDF-GHJK
+✓ Credential validated and saved securely
+```
+
+The code is valid for ten minutes. Use `--no-browser` on a machine with no
+browser (the URL still prints, and can be opened anywhere you are signed in), or
+`skyportalai login --token` to paste an existing `sk_` key instead. A deployment
+that predates the handshake falls back to the key page automatically.
 
 `login` prints the instance it is connecting to before prompting, so check that
 line if you are not sure which deployment the key will belong to. A saved

--- a/skyportalai/cli/shell_commands.py
+++ b/skyportalai/cli/shell_commands.py
@@ -115,30 +115,65 @@ def configure(
 
 def login(
     no_browser: Annotated[
-        bool, typer.Option("--no-browser", help="Print the API-key URL without opening it")
+        bool, typer.Option("--no-browser", help="Print the login URL without opening it")
     ] = False,
     enter_token: Annotated[bool, typer.Option("--token", help="Paste an existing API key")] = False,
 ) -> None:
-    """Create or paste an account API key and connect the CLI."""
+    """Connect the CLI by approving it in the browser, or by pasting a key."""
     _announce_target()
     client = _portal_client()
     try:
-        if not enter_token:
-            result = client.login(open_browser=not no_browser)
-            console.print(
-                "[bold]Create or copy a Skyportal account API key:[/bold] {}".format(result["verification_url"])
-            )
-            console.print(
-                "Create a key named [bold]Skyportal CLI[/bold] and copy the [bold]sk_[/bold] value.\n"
-                "[dim]Do not use an agt_ observability-agent token.[/dim]"
-            )
-            if not result.get("browser_opened") and not no_browser:
-                console.print("[yellow]Browser did not open; use the URL above.[/yellow]")
-        access_token = typer.prompt("Skyportal API key", hide_input=True)
-        client.set_access_token(access_token)
+        handshake = None if enter_token else client.begin_device_login()
+        if handshake is None:
+            _connect_by_pasting_a_key(client, show_key_page=not enter_token, open_browser=not no_browser)
+        else:
+            _connect_through_the_browser(client, handshake, open_browser=not no_browser)
     except PortalError as error:
         raise _fail(error) from None
     console.print("[green]✓[/green] Credential validated and saved securely")
+
+
+def _connect_through_the_browser(client: SkyportalClient, handshake, *, open_browser: bool) -> None:
+    """Show the code, then wait for the browser to approve it.
+
+    The CLI used to open the key page and block on a paste, with no way for the
+    browser to answer. It now polls the deployment, so the terminal finishes on
+    its own once someone approves the code.
+    """
+    console.print(
+        "Confirm this code to connect: [bold]{}[/bold]\n{}".format(
+            handshake.user_code, handshake.verification_uri_complete
+        )
+    )
+    if open_browser and not client.open_verification_page(handshake.verification_uri_complete):
+        console.print("[yellow]Browser did not open; use the URL above.[/yellow]")
+    try:
+        with console.status("[cyan]Waiting for approval in the browser…[/cyan]", spinner="dots"):
+            access_token = client.await_device_login(handshake)
+    except KeyboardInterrupt:
+        console.print(
+            "\n[yellow]Cancelled.[/yellow] Run [bold]skyportalai login --token[/bold] to paste a key instead."
+        )
+        raise typer.Exit(1) from None
+    with console.status("[cyan]Validating credential…[/cyan]", spinner="dots"):
+        client.set_access_token(access_token)
+
+
+def _connect_by_pasting_a_key(client: SkyportalClient, *, show_key_page: bool, open_browser: bool) -> None:
+    """The manual route: --token, or a deployment without the handshake endpoint."""
+    if show_key_page:
+        result = client.login(open_browser=open_browser)
+        console.print(
+            "[bold]Create or copy a Skyportal account API key:[/bold] {}".format(result["verification_url"])
+        )
+        console.print(
+            "Create a key named [bold]Skyportal CLI[/bold] and copy the [bold]sk_[/bold] value.\n"
+            "[dim]Do not use an agt_ observability-agent token.[/dim]"
+        )
+        if not result.get("browser_opened") and open_browser:
+            console.print("[yellow]Browser did not open; use the URL above.[/yellow]")
+    access_token = typer.prompt("Skyportal API key", hide_input=True)
+    client.set_access_token(access_token)
 
 
 def logout() -> None:

--- a/skyportalai/cli/shell_commands.py
+++ b/skyportalai/cli/shell_commands.py
@@ -123,7 +123,7 @@ def login(
     _announce_target()
     client = _portal_client()
     try:
-        handshake = None if enter_token else client.begin_device_login()
+        handshake = None if enter_token else _begin_handshake(client)
         if handshake is None:
             _connect_by_pasting_a_key(client, show_key_page=not enter_token, open_browser=not no_browser)
         else:
@@ -131,6 +131,22 @@ def login(
     except PortalError as error:
         raise _fail(error) from None
     console.print("[green]✓[/green] Credential validated and saved securely")
+
+
+def _begin_handshake(client: SkyportalClient):
+    """Start the browser handshake, naming the manual route if it cannot start.
+
+    A deployment without the endpoint reports no handshake and falls back
+    silently. Everything else — a 502, an unreachable host — is a real failure,
+    and the way past it is the paste route, so the error says so.
+    """
+    try:
+        return client.begin_device_login()
+    except PortalError as error:
+        raise PortalError(
+            f"{error} Could not start a browser login; "
+            "run 'skyportalai login --token' to paste a key instead."
+        ) from None
 
 
 def _connect_through_the_browser(client: SkyportalClient, handshake, *, open_browser: bool) -> None:

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -27,6 +27,7 @@ from .portal import (
     PRODUCTION_APP_URL,
     ChatTurnResult,
     CredentialStore,
+    DeviceLogin,
     PortalError,
     SkyportalClient,
 )
@@ -413,9 +414,48 @@ class InteractiveShell:
                 "[yellow]Do not put credentials in command history. Type /token by itself.[/yellow]"
             )
             return
-        self._connect_from_key_page(open_browser=True)
+        # /token is the deliberate paste route, so it skips the browser handshake.
+        self._connect_by_pasting_a_key(open_browser=True)
 
     def _connect_from_key_page(self, open_browser: bool) -> None:
+        """Connect this terminal, by browser approval where the deployment allows it."""
+        handshake = self.client.begin_device_login()
+        if handshake is not None:
+            self._connect_by_browser_approval(handshake, open_browser)
+            return
+        self._connect_by_pasting_a_key(open_browser)
+
+    def _connect_by_browser_approval(self, handshake: DeviceLogin, open_browser: bool) -> None:
+        self.browser_login_started = True
+        details = Text()
+        details.append("Connect this terminal in two steps:\n\n", style="bold green")
+        details.append("1. Open the authorization page:\n")
+        details.append(
+            handshake.verification_uri_complete,
+            style="bold cyan link {}".format(handshake.verification_uri_complete),
+        )
+        details.append("\n\n2. Confirm the code ")
+        details.append(handshake.user_code, style="bold")
+        details.append(" and approve.\n\nThis terminal finishes on its own once you approve.")
+        if open_browser and not self.client.open_verification_page(handshake.verification_uri_complete):
+            details.append("\nYour browser did not open; use the link above.", style="yellow")
+        self._print_section("Connect Skyportal CLI")
+        self.console.print(details)
+        self.console.print()
+        try:
+            with self.console.status("[cyan]Waiting for approval in the browser…[/cyan]", spinner="dots"):
+                token = self.client.await_device_login(handshake)
+        except (KeyboardInterrupt, EOFError):
+            self.console.print(
+                "[yellow]Login cancelled.[/yellow] Run [bold]/token[/bold] to paste a key instead."
+            )
+            return
+        with self.console.status("[cyan]Validating API credential…[/cyan]", spinner="dots"):
+            self.client.set_access_token(token)
+        self.browser_login_started = False
+        self.console.print("[green]✓ Credential validated and saved securely.[/green]")
+
+    def _connect_by_pasting_a_key(self, open_browser: bool) -> None:
         result = self.client.login(open_browser=open_browser)
         self.browser_login_started = True
         url = str(result["verification_url"])

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -443,17 +443,19 @@ class InteractiveShell:
         self.console.print(details)
         self.console.print()
         try:
-            with self.console.status("[cyan]Waiting for approval in the browser…[/cyan]", spinner="dots"):
-                token = self.client.await_device_login(handshake)
-        except (KeyboardInterrupt, EOFError):
-            self.console.print(
-                "[yellow]Login cancelled.[/yellow] Run [bold]/token[/bold] to paste a key instead."
-            )
-            return
-        with self.console.status("[cyan]Validating API credential…[/cyan]", spinner="dots"):
-            self.client.set_access_token(token)
-        self.browser_login_started = False
-        self.console.print("[green]✓ Credential validated and saved securely.[/green]")
+            try:
+                with self.console.status("[cyan]Waiting for approval in the browser…[/cyan]", spinner="dots"):
+                    token = self.client.await_device_login(handshake)
+            except (KeyboardInterrupt, EOFError):
+                self.console.print(
+                    "[yellow]Login cancelled.[/yellow] Run [bold]/token[/bold] to paste a key instead."
+                )
+                return
+            with self.console.status("[cyan]Validating API credential…[/cyan]", spinner="dots"):
+                self.client.set_access_token(token)
+            self.console.print("[green]✓ Credential validated and saved securely.[/green]")
+        finally:
+            self.browser_login_started = False
 
     def _connect_by_pasting_a_key(self, open_browser: bool) -> None:
         result = self.client.login(open_browser=open_browser)

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import socket
 import tempfile
 import time
 import webbrowser
@@ -20,6 +21,14 @@ from skyportalai._version import __version__
 PRODUCTION_MARKETING_URL = "https://skyportal.ai"
 PRODUCTION_APP_URL = "https://app.skyportal.ai"
 CLI_USER_AGENT = f"Skyportal-CLI/{__version__} (+https://app.skyportal.ai)"
+
+CLI_LOGIN_START_PATH = "/api/v1/cli/login/start/"
+CLI_LOGIN_POLL_PATH = "/api/v1/cli/login/poll/"
+# A deployment that predates the handshake answers these with 404/405; the caller
+# then falls back to the manual key page rather than failing the login.
+_NO_HANDSHAKE_STATUSES = frozenset({404, 405})
+_MIN_POLL_INTERVAL = 1
+_MAX_POLL_INTERVAL = 30
 
 _BUSY_CHAT_STATUSES = {"processing", "uninitialized"}
 _IMMEDIATE_CHAT_STATUSES = {"awaiting_approval", "error"}
@@ -57,6 +66,18 @@ class PortalError(RuntimeError):
 
 
 @dataclass(frozen=True)
+class DeviceLogin:
+    """A browser handshake the CLI is waiting on."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    interval: int
+    expires_in: int
+
+
+@dataclass(frozen=True)
 class ChatTurnResult:
     """Result of one headless Skyportal agent turn."""
 
@@ -65,6 +86,14 @@ class ChatTurnResult:
     messages: List[Dict[str, Any]]
     pending_approvals: List[Dict[str, Any]]
     latest_sequence: int
+
+
+def _local_client_name() -> str:
+    """The machine name shown on the approval page, so a user can recognise it."""
+    try:
+        return socket.gethostname()[:60]
+    except OSError:
+        return ""
 
 
 class CredentialStore:
@@ -162,6 +191,83 @@ class SkyportalClient:
             "verification_url": verification_url,
             "browser_opened": browser_opened,
         }
+
+    def begin_device_login(self) -> Optional[DeviceLogin]:
+        """Start a browser handshake, or None if this deployment has no endpoint.
+
+        Returning None rather than raising is what lets `login` keep working
+        against a Skyportal that has not deployed the handshake yet: the caller
+        falls back to the key page and a pasted credential.
+        """
+        body = {"client_name": _local_client_name(), "client_version": __version__}
+        try:
+            payload = self._request(
+                "POST", CLI_LOGIN_START_PATH, json_body=body, authenticated=False
+            )
+        except PortalError as error:
+            if error.status_code in _NO_HANDSHAKE_STATUSES:
+                return None
+            raise
+        if not isinstance(payload, dict):
+            raise PortalError("Skyportal returned an unexpected login response")
+        try:
+            return DeviceLogin(
+                device_code=str(payload["device_code"]),
+                user_code=str(payload["user_code"]),
+                verification_uri=str(payload["verification_uri"]),
+                verification_uri_complete=str(
+                    payload.get("verification_uri_complete") or payload["verification_uri"]
+                ),
+                interval=int(payload.get("interval") or _MIN_POLL_INTERVAL),
+                expires_in=int(payload.get("expires_in") or 600),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise PortalError("Skyportal returned an incomplete login response") from error
+
+    def await_device_login(
+        self,
+        handshake: DeviceLogin,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> str:
+        """Poll until the browser approves the handshake, returning the new API key."""
+        interval = min(max(handshake.interval, _MIN_POLL_INTERVAL), _MAX_POLL_INTERVAL)
+        deadline = time.monotonic() + max(handshake.expires_in, interval)
+        while True:
+            payload = self._request(
+                "POST",
+                CLI_LOGIN_POLL_PATH,
+                json_body={"device_code": handshake.device_code},
+                authenticated=False,
+            )
+            payload = payload if isinstance(payload, dict) else {}
+            status = str(payload.get("status") or "")
+            if status == "approved":
+                key = str(payload.get("key") or "")
+                if not key:
+                    raise PortalError("Skyportal approved the login but returned no API key")
+                return key
+            if status == "denied":
+                raise PortalError("The login was denied in the browser. Nothing was saved.")
+            if status == "expired":
+                raise PortalError(
+                    "The login request expired before it was approved. "
+                    "Run 'skyportalai login' again."
+                )
+            if time.monotonic() >= deadline:
+                raise PortalError(
+                    "Timed out waiting for the browser to approve this login. "
+                    "Run 'skyportalai login' again."
+                )
+            # The server may ask for a slower cadence than it first advertised.
+            interval = min(max(int(payload.get("interval") or interval), _MIN_POLL_INTERVAL), _MAX_POLL_INTERVAL)
+            sleep(interval)
+
+    def open_verification_page(self, url: str) -> bool:
+        """Open a handshake URL in the browser, reporting whether that worked."""
+        try:
+            return bool(webbrowser.open(url))
+        except webbrowser.Error:
+            return False
 
     def api_key_url(self) -> str:
         """Return the account API-key page used by the CLI."""

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -24,9 +24,13 @@ CLI_USER_AGENT = f"Skyportal-CLI/{__version__} (+https://app.skyportal.ai)"
 
 CLI_LOGIN_START_PATH = "/api/v1/cli/login/start/"
 CLI_LOGIN_POLL_PATH = "/api/v1/cli/login/poll/"
-# A deployment that predates the handshake answers these with 404/405; the caller
-# then falls back to the manual key page rather than failing the login.
-_NO_HANDSHAKE_STATUSES = frozenset({404, 405})
+# A deployment that predates the handshake answers these with 404/405, and an
+# edge or WAF in front of one can answer 403; either way there is no handshake to
+# be had, so the caller falls back to the manual key page instead of failing.
+_NO_HANDSHAKE_STATUSES = frozenset({403, 404, 405})
+# Poll failures that say nothing about the authorization itself: a 502 from a
+# proxy, a throttle, a dropped connection. They cost time, not the login.
+_TRANSIENT_POLL_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 _MIN_POLL_INTERVAL = 1
 _MAX_POLL_INTERVAL = 30
 
@@ -86,6 +90,12 @@ class ChatTurnResult:
     messages: List[Dict[str, Any]]
     pending_approvals: List[Dict[str, Any]]
     latest_sequence: int
+
+
+def _is_transient(error: PortalError) -> bool:
+    """Whether a failed poll says nothing about the authorization's state."""
+    # status_code is None for connection failures and timeouts.
+    return error.status_code is None or error.status_code in _TRANSIENT_POLL_STATUSES
 
 
 def _local_client_name() -> str:
@@ -232,13 +242,26 @@ class SkyportalClient:
         """Poll until the browser approves the handshake, returning the new API key."""
         interval = min(max(handshake.interval, _MIN_POLL_INTERVAL), _MAX_POLL_INTERVAL)
         deadline = time.monotonic() + max(handshake.expires_in, interval)
+        backoff = interval
         while True:
-            payload = self._request(
-                "POST",
-                CLI_LOGIN_POLL_PATH,
-                json_body={"device_code": handshake.device_code},
-                authenticated=False,
-            )
+            try:
+                payload = self._request(
+                    "POST",
+                    CLI_LOGIN_POLL_PATH,
+                    json_body={"device_code": handshake.device_code},
+                    authenticated=False,
+                )
+            except PortalError as error:
+                # One bad poll must not discard an approval the user may have
+                # already given: a 502 or a dropped connection at second 30 of
+                # 600 costs a retry, not the login. Anything that describes the
+                # request itself (a 400, a vanished endpoint) still stops.
+                if not _is_transient(error) or time.monotonic() >= deadline:
+                    raise
+                sleep(backoff)
+                backoff = min(backoff * 2, _MAX_POLL_INTERVAL)
+                continue
+            backoff = interval
             payload = payload if isinstance(payload, dict) else {}
             status = str(payload.get("status") or "")
             if status == "approved":

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -216,12 +216,21 @@ class SkyportalClient:
         if not isinstance(payload, dict):
             raise PortalError("Skyportal returned an unexpected login response")
         try:
+            device_code = payload["device_code"]
+            user_code = payload["user_code"]
+            verification_uri = payload["verification_uri"]
+            if not isinstance(device_code, str) or not device_code:
+                raise PortalError("Skyportal returned an incomplete login response")
+            if not isinstance(user_code, str) or not user_code:
+                raise PortalError("Skyportal returned an incomplete login response")
+            if not isinstance(verification_uri, str) or not verification_uri:
+                raise PortalError("Skyportal returned an incomplete login response")
             return DeviceLogin(
-                device_code=str(payload["device_code"]),
-                user_code=str(payload["user_code"]),
-                verification_uri=str(payload["verification_uri"]),
+                device_code=device_code,
+                user_code=user_code,
+                verification_uri=verification_uri,
                 verification_uri_complete=str(
-                    payload.get("verification_uri_complete") or payload["verification_uri"]
+                    payload.get("verification_uri_complete") or verification_uri
                 ),
                 interval=int(payload.get("interval") or _MIN_POLL_INTERVAL),
                 expires_in=int(payload.get("expires_in") or 600),
@@ -277,7 +286,10 @@ class SkyportalClient:
                     "Run 'skyportalai login' again."
                 )
             # The server may ask for a slower cadence than it first advertised.
-            interval = min(max(int(payload.get("interval") or interval), _MIN_POLL_INTERVAL), _MAX_POLL_INTERVAL)
+            try:
+                interval = min(max(int(payload.get("interval") or interval), _MIN_POLL_INTERVAL), _MAX_POLL_INTERVAL)
+            except (TypeError, ValueError) as error:
+                raise PortalError("Skyportal returned an invalid poll interval") from error
             sleep(interval)
 
     def open_verification_page(self, url: str) -> bool:

--- a/tests/test_device_login.py
+++ b/tests/test_device_login.py
@@ -1,0 +1,301 @@
+"""The browser handshake behind `skyportalai login` (#3404).
+
+`login` used to open the key page and block on a paste the browser could never
+answer. It now starts an authorization, shows a short code and polls, so the
+terminal finishes on its own — and still falls back to the paste when the
+deployment has no handshake endpoint.
+"""
+
+import json
+from io import BytesIO
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+import pytest
+from typer.testing import CliRunner
+
+from skyportalai.cli.main import app
+from skyportalai.shell.portal import CredentialStore, PortalError, SkyportalClient
+
+runner = CliRunner()
+
+STARTED = {
+    "device_code": "device-secret",
+    "user_code": "BCDF-GHJK",
+    "verification_uri": "https://app.skyportal.ai/cli/authorize/",
+    "verification_uri_complete": "https://app.skyportal.ai/cli/authorize/?code=BCDF-GHJK",
+    "interval": 5,
+    "expires_in": 600,
+}
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+def _http_error(status):
+    return HTTPError(
+        "https://app.skyportal.ai/api/v1/cli/login/start/",
+        status,
+        "error",
+        hdrs=None,
+        fp=BytesIO(b"{}"),
+    )
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKYPORTALAI_CONFIG_PATH", str(tmp_path / "config.yaml"))
+    monkeypatch.setenv("SKYPORTALAI_CREDENTIALS_PATH", str(tmp_path / "credentials.json"))
+    for name in ("SKYPORTALAI_API_KEY", "SKYPORTALAI_ACCESS_TOKEN", "SKYPORTALAI_BASE_URL", "SKYPORTALAI_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("COLUMNS", "300")
+    return tmp_path / "credentials.json"
+
+
+def test_begin_device_login_reads_the_handshake(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse(STARTED)) as call:
+        handshake = client.begin_device_login()
+
+    assert handshake.user_code == "BCDF-GHJK"
+    assert handshake.verification_uri_complete.endswith("?code=BCDF-GHJK")
+    assert handshake.interval == 5
+    request = call.call_args[0][0]
+    assert request.full_url == "https://app.skyportal.ai/api/v1/cli/login/start/"
+    # Unauthenticated by design: this is what a CLI with no credential calls.
+    assert "Authorization" not in request.headers
+    body = json.loads(request.data.decode())
+    assert body["client_version"]
+
+
+def test_a_deployment_without_the_endpoint_reports_no_handshake(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(404)):
+        assert client.begin_device_login() is None
+
+
+def test_other_failures_are_not_mistaken_for_a_missing_endpoint(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(500)):
+        with pytest.raises(PortalError):
+            client.begin_device_login()
+
+
+def test_polling_waits_through_pending_and_returns_the_key(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse(STARTED)):
+        handshake = client.begin_device_login()
+    slept = []
+    responses = [
+        FakeResponse({"status": "pending", "interval": 1}),
+        FakeResponse({"status": "pending", "interval": 1}),
+        FakeResponse({"status": "approved", "key": "sk_delivered"}),
+    ]
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=responses):
+        key = client.await_device_login(handshake, sleep=slept.append)
+
+    assert key == "sk_delivered"
+    assert slept == [1, 1]
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("denied", "denied in the browser"),
+        ("expired", "expired before it was approved"),
+    ],
+)
+def test_a_refused_handshake_says_so_instead_of_waiting(isolated, status, expected):
+    client = SkyportalClient("https://app.skyportal.ai")
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse(STARTED)):
+        handshake = client.begin_device_login()
+
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse({"status": status})):
+        with pytest.raises(PortalError, match=expected):
+            client.await_device_login(handshake, sleep=lambda _seconds: None)
+
+
+def test_an_approval_without_a_key_is_an_error_not_an_empty_credential(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse(STARTED)):
+        handshake = client.begin_device_login()
+
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse({"status": "approved"})):
+        with pytest.raises(PortalError, match="no API key"):
+            client.await_device_login(handshake, sleep=lambda _seconds: None)
+
+
+def test_login_completes_without_a_prompt_once_the_browser_approves(isolated):
+    responses = [
+        FakeResponse(STARTED),
+        FakeResponse({"status": "approved", "key": "sk_delivered"}),
+        FakeResponse([]),  # the credential is validated before it is saved
+    ]
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=responses):
+        with patch("skyportalai.shell.portal.webbrowser.open", return_value=True) as browser:
+            result = runner.invoke(app, ["login"], input="")
+
+    assert result.exit_code == 0, result.output
+    assert "BCDF-GHJK" in result.output
+    assert "Skyportal API key" not in result.output
+    browser.assert_called_once_with(STARTED["verification_uri_complete"])
+    assert json.loads(isolated.read_text())["access_token"] == "sk_delivered"
+
+
+def test_no_browser_prints_the_url_without_opening_it(isolated):
+    responses = [
+        FakeResponse(STARTED),
+        FakeResponse({"status": "approved", "key": "sk_delivered"}),
+        FakeResponse([]),
+    ]
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=responses):
+        with patch("skyportalai.shell.portal.webbrowser.open", return_value=True) as browser:
+            result = runner.invoke(app, ["login", "--no-browser"], input="")
+
+    assert result.exit_code == 0, result.output
+    assert STARTED["verification_uri_complete"] in result.output
+    browser.assert_not_called()
+
+
+def test_login_falls_back_to_pasting_when_the_deployment_has_no_handshake(isolated):
+    def responses(request, **kwargs):
+        if request.full_url.endswith("/api/v1/cli/login/start/"):
+            raise _http_error(404)
+        return FakeResponse([])
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=responses):
+        with patch("skyportalai.shell.portal.webbrowser.open", return_value=True):
+            result = runner.invoke(app, ["login"], input="sk_pasted\n")
+
+    assert result.exit_code == 0, result.output
+    assert "/keys/?source=cli" in result.output
+    assert json.loads(isolated.read_text())["access_token"] == "sk_pasted"
+
+
+def test_token_flag_skips_the_handshake_entirely(isolated):
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse([])) as call:
+        result = runner.invoke(app, ["login", "--token"], input="sk_pasted\n")
+
+    assert result.exit_code == 0, result.output
+    assert "cli/authorize" not in result.output
+    # One call only: the credential validation. No handshake was started.
+    assert len(call.call_args_list) == 1
+    assert json.loads(isolated.read_text())["access_token"] == "sk_pasted"
+
+
+def test_a_cancelled_wait_points_at_the_manual_route(isolated):
+    responses = [FakeResponse(STARTED)]
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=responses):
+        with patch("skyportalai.shell.portal.webbrowser.open", return_value=True):
+            with patch(
+                "skyportalai.shell.portal.SkyportalClient.await_device_login",
+                side_effect=KeyboardInterrupt,
+            ):
+                result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "skyportalai login --token" in result.output
+    assert not isolated.exists()
+    assert CredentialStore.load() is None
+
+
+class _HandshakeClient:
+    """Just enough client for the interactive shell's connect paths."""
+
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self, handshake):
+        self._handshake = handshake
+        self.saved = []
+        self.paste_page_opened = 0
+        self.opened = []
+
+    def is_authenticated(self):
+        return False
+
+    def begin_device_login(self):
+        return self._handshake
+
+    def open_verification_page(self, url):
+        self.opened.append(url)
+        return True
+
+    def await_device_login(self, handshake, sleep=None):
+        return "sk_from_browser"
+
+    def login(self, open_browser=True):
+        self.paste_page_opened += 1
+        return {"verification_url": "https://app.skyportal.ai/keys/?source=cli", "browser_opened": True}
+
+    def set_access_token(self, token, validate=True):
+        self.saved.append(token)
+
+
+def _shell(monkeypatch, tmp_path, handshake):
+    from io import StringIO
+
+    from rich.console import Console
+
+    from skyportalai.shell.interactive import InteractiveShell
+
+    monkeypatch.setenv("SKYPORTALAI_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    out = StringIO()
+    client = _HandshakeClient(handshake)
+    shell = InteractiveShell(console=Console(file=out, width=200, force_terminal=False), client_factory=lambda: client)
+    return shell, client, out
+
+
+def test_the_shell_login_command_uses_the_browser_handshake(monkeypatch, tmp_path):
+    from skyportalai.shell.portal import DeviceLogin
+
+    handshake = DeviceLogin(**STARTED)
+    shell, client, out = _shell(monkeypatch, tmp_path, handshake)
+
+    shell._cmd_login([])
+
+    assert client.saved == ["sk_from_browser"]
+    assert client.opened == [STARTED["verification_uri_complete"]]
+    assert client.paste_page_opened == 0
+    assert "BCDF-GHJK" in out.getvalue()
+
+
+def test_the_shell_falls_back_to_the_key_page_without_a_handshake(monkeypatch, tmp_path):
+    shell, client, out = _shell(monkeypatch, tmp_path, None)
+    shell._token_prompt = lambda _prompt: "sk_pasted"
+
+    shell._cmd_login([])
+
+    assert client.paste_page_opened == 1
+    assert client.saved == ["sk_pasted"]
+
+
+def test_the_shell_token_command_still_pastes(monkeypatch, tmp_path):
+    from skyportalai.shell.portal import DeviceLogin
+
+    shell, client, out = _shell(monkeypatch, tmp_path, DeviceLogin(**STARTED))
+    shell._token_prompt = lambda _prompt: "sk_pasted"
+
+    shell._cmd_token([])
+
+    assert client.paste_page_opened == 1
+    assert client.saved == ["sk_pasted"]
+    assert client.opened == []

--- a/tests/test_device_login.py
+++ b/tests/test_device_login.py
@@ -9,13 +9,13 @@ deployment has no handshake endpoint.
 import json
 from io import BytesIO
 from unittest.mock import patch
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import pytest
 from typer.testing import CliRunner
 
 from skyportalai.cli.main import app
-from skyportalai.shell.portal import CredentialStore, PortalError, SkyportalClient
+from skyportalai.shell.portal import CredentialStore, DeviceLogin, PortalError, SkyportalClient
 
 runner = CliRunner()
 
@@ -42,6 +42,19 @@ class FakeResponse:
 
     def read(self):
         return json.dumps(self.payload).encode()
+
+
+class _Clock:
+    """A monotonic clock the injected sleep advances, so deadlines are testable."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
 
 
 def _http_error(status):
@@ -81,10 +94,12 @@ def test_begin_device_login_reads_the_handshake(isolated):
     assert body["client_version"]
 
 
-def test_a_deployment_without_the_endpoint_reports_no_handshake(isolated):
+@pytest.mark.parametrize("status", [403, 404, 405])
+def test_a_deployment_without_the_endpoint_reports_no_handshake(isolated, status):
+    # 404/405 predates the handshake; 403 is an edge or WAF in front of one.
     client = SkyportalClient("https://app.skyportal.ai")
 
-    with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(404)):
+    with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(status)):
         assert client.begin_device_login() is None
 
 
@@ -94,6 +109,51 @@ def test_other_failures_are_not_mistaken_for_a_missing_endpoint(isolated):
     with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(500)):
         with pytest.raises(PortalError):
             client.begin_device_login()
+
+
+def test_a_transient_poll_failure_costs_a_retry_not_the_login(isolated):
+    # The user may already have clicked approve; a 502 at second 30 of 600 must
+    # not throw that away.
+    client = SkyportalClient("https://app.skyportal.ai")
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse(STARTED)):
+        handshake = client.begin_device_login()
+    slept = []
+    responses = [
+        _http_error(502),
+        URLError("connection reset"),
+        _http_error(429),
+        FakeResponse({"status": "approved", "key": "sk_delivered"}),
+    ]
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=responses):
+        key = client.await_device_login(handshake, sleep=slept.append)
+
+    assert key == "sk_delivered"
+    # Backs off while the far side is unhappy, rather than hammering it.
+    assert slept == [5, 10, 20]
+
+
+def test_a_failure_about_the_request_itself_still_stops(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+    with patch("skyportalai.shell.portal.urlopen", return_value=FakeResponse(STARTED)):
+        handshake = client.begin_device_login()
+
+    with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(400)):
+        with pytest.raises(PortalError):
+            client.await_device_login(handshake, sleep=lambda _seconds: None)
+
+
+def test_transient_failures_stop_at_the_deadline(isolated):
+    client = SkyportalClient("https://app.skyportal.ai")
+    handshake = DeviceLogin(**{**STARTED, "interval": 1, "expires_in": 4})
+    clock = _Clock()
+
+    with patch("skyportalai.shell.portal.time.monotonic", clock.monotonic):
+        with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(503)):
+            with pytest.raises(PortalError):
+                client.await_device_login(handshake, sleep=clock.sleep)
+
+    assert clock.now >= 4
 
 
 def test_polling_waits_through_pending_and_returns_the_key(isolated):
@@ -173,6 +233,15 @@ def test_no_browser_prints_the_url_without_opening_it(isolated):
     assert result.exit_code == 0, result.output
     assert STARTED["verification_uri_complete"] in result.output
     browser.assert_not_called()
+
+
+def test_a_start_failure_names_the_paste_route(isolated):
+    with patch("skyportalai.shell.portal.urlopen", side_effect=_http_error(502)):
+        result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "skyportalai login --token" in result.output
+    assert not isolated.exists()
 
 
 def test_login_falls_back_to_pasting_when_the_deployment_has_no_handshake(isolated):


### PR DESCRIPTION
Fixes SkyportalAi/skyportal-website#3404 — the CLI half. The website half is SkyportalAi/skyportal-website#3405 and has to ship first.

## Problem

`skyportalai login` opened the key page and then blocked on a hidden prompt the browser could never answer — no local listener, no device code, nothing polled. The user had to notice the still-waiting terminal behind the browser window, create a key, copy it, switch back and paste it. This is the first thing a new user does after installing.

## Change

```
$ skyportalai login
Connecting to https://app.skyportal.ai
Confirm this code to connect: BCDF-GHJK
https://app.skyportal.ai/cli/authorize/?code=BCDF-GHJK
⠋ Waiting for approval in the browser…
✓ Credential validated and saved securely
```

`login` starts an authorization, prints the code and the page that confirms it, opens that page, then polls until someone approves — and validates and saves the key it is handed. `/login` in the interactive shell takes the same route, so the two cannot drift.

### Edges, deliberately

- **A deployment without the handshake still works.** The start call answering 404/405 means "no handshake here", not failure, and the old key-page paste runs instead. This matters during rollout: the CLI ships from git and PyPI independently of the site.
- **`--token` and `/token` still paste**, with no handshake started at all.
- **Ctrl-C while waiting** says how to paste instead, and saves nothing.
- The poll honours the interval the server advertises, stops on `denied`/`expired` rather than waiting out the clock, and treats an approval with no key as an error rather than saving an empty credential.
- The machine name goes out with the start call so the approval page can show which terminal is asking. That is one hostname, sent to the deployment you are logging into.

## Tests

`tests/test_device_login.py` — 15 tests: the handshake read, 404/405 → fallback vs 500 → error, pending→approved polling with the advertised interval, denied/expired/keyless-approval, `login` completing with no prompt, `--no-browser`, the paste fallback, `--token` starting no handshake, Ctrl-C leaving nothing saved, and the three interactive-shell paths. Full suite 551 passed, `ruff check` clean.

Verified end to end against the real Django views from #3405: a `skyportalai login --no-browser` subprocess pointed at them, approved through the page, exits 0 with the minted `Skyportal CLI` key saved — and its output contains no paste prompt.

## Note

Unrelated but still open: the 0.2.2 release never shipped (#61 was squash-merged from a stale head, so the version bump was left behind). None of this reaches users installing from PyPI until a release goes out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-based device login for `skyportalai login` and interactive `/login`.
  * Displays a short verification code and approval page, then completes sign-in automatically.
  * Added `--no-browser` for manually opening the verification page.
  * Added explicit `--token` and `/token` options for API-key entry.

* **Bug Fixes**
  * Added fallback to API-key login when device authentication is unavailable.
  * Improved handling of transient connection failures, cancellation, expiration, and denied approvals.

* **Documentation**
  * Updated deployment and changelog documentation with the new login flow and available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->