### PR TITLE
feat(shell): /upload attaches logs and exports to the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here. This project follows
 
 ## Unreleased
 
+### Added
+
+- **`/upload <path>` attaches a file to the chat.** Logs, CSV, JSON, YAML and
+  images, up to 10 MB each. Ask about the file by name afterwards; the agent
+  reads what you attach. Secrets in a log are redacted before it leaves the
+  server's front door, so a stray API key is never stored. Requires a deployment
+  with the `/api/v1/agent/chat/<id>/upload/` route.
+
 ## 0.2.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project are documented here. This project follows
   reads what you attach. Secrets in a log are redacted before it leaves the
   server's front door, so a stray API key is never stored. Requires a deployment
   with the `/api/v1/agent/chat/<id>/upload/` route.
+- **Dropping a file on the terminal attaches it too.** A terminal types the
+  path when you drag a file onto it, so a line that is nothing but existing
+  absolute paths is treated as an upload rather than a message. Handles the
+  quoting and backslash-escaping different terminals apply, `file://` URIs, and
+  several files at once. A relative path stays a message, so asking about
+  `vllm.log` from a directory containing one still asks.
 
 ## 0.2.2
 

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import unquote, urlparse
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import Completer, Completion
@@ -70,7 +71,7 @@ COMMANDS: Dict[str, CommandInfo] = {
     ),
     "/upload": CommandInfo(
         "/upload <path> [path…]",
-        "Attach a log, CSV, JSON or image to this chat",
+        "Attach a log, CSV, JSON or image — or just drop the file on the terminal",
     ),
     "/servers": CommandInfo("/servers", "List your Skyportal servers"),
     "/server": CommandInfo(
@@ -259,10 +260,7 @@ class InteractiveShell:
             if not line:
                 continue
             try:
-                if line.startswith("/"):
-                    self._dispatch(line)
-                else:
-                    self._send_prompt(line)
+                self._route(line)
             except KeyboardInterrupt:
                 self.console.print("\n[yellow]Cancelled — the prompt is still active.[/yellow]")
             except PortalError as error:
@@ -377,6 +375,60 @@ class InteractiveShell:
         )
         self.console.print(body)
         self.console.print()
+
+    def _route(self, line: str) -> None:
+        """Send a line to the agent, a command, or the uploader.
+
+        Dropping a file on the terminal types its path at the prompt, so a drop
+        arrives here as ordinary text and has to be recognised as one.
+        """
+        dropped = self._dropped_files(line)
+        if dropped is not None:
+            self._upload_dropped(dropped)
+        elif line.startswith("/"):
+            self._dispatch(line)
+        else:
+            self._send_prompt(line)
+
+    @staticmethod
+    def _dropped_files(line: str) -> Optional[List[str]]:
+        """The paths in a line that is nothing but existing files, else None.
+
+        A terminal types the path when a file is dropped on it, quoting or
+        backslash-escaping any spaces, so shlex is what un-does that. Every token
+        must be an absolute path to a real file: "/upload x.log" keeps its handler
+        because /upload is not a file, and "check vllm.log" stays a message
+        because a bare filename is not absolute.
+        """
+        try:
+            tokens = shlex.split(line)
+        except ValueError:
+            # An apostrophe in a sentence is an unbalanced quote. That is a
+            # message, not a parse error to report.
+            return None
+        if not tokens:
+            return None
+
+        paths = []
+        for token in tokens:
+            if token.startswith("file://"):
+                token = unquote(urlparse(token).path)
+            candidate = Path(token).expanduser()
+            # isabs first: a message should not stat every word in it.
+            if not candidate.is_absolute() or not candidate.is_file():
+                return None
+            paths.append(str(candidate))
+        return paths
+
+    def _upload_dropped(self, paths: List[str]) -> None:
+        if self.chat_id is None:
+            names = ", ".join(Path(path).name for path in paths)
+            self.console.print(
+                "[yellow]Got {} — send a message to start the chat, then drop it "
+                "again or run /upload.[/yellow]".format(names)
+            )
+            return
+        self._cmd_upload(paths)
 
     def _dispatch(self, line: str) -> None:
         try:

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -16,8 +16,8 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import prompt as secure_prompt
 from prompt_toolkit.styles import Style
 from rich.console import Console
-from rich.markup import escape
 from rich.markdown import Markdown
+from rich.markup import escape
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -68,6 +68,10 @@ COMMANDS: Dict[str, CommandInfo] = {
         "/resume [chat_id] [--verbose]",
         "Reattach to a chat (defaults to your previous one); --verbose replays its history",
     ),
+    "/upload": CommandInfo(
+        "/upload <path> [path…]",
+        "Attach a log, CSV, JSON or image to this chat",
+    ),
     "/servers": CommandInfo("/servers", "List your Skyportal servers"),
     "/server": CommandInfo(
         "/server <name> [name ...] | auto",
@@ -173,6 +177,7 @@ class InteractiveShell:
             "/permission": self._cmd_permission,
             "/new": self._cmd_new,
             "/resume": self._cmd_resume,
+            "/upload": self._cmd_upload,
             "/servers": self._cmd_servers,
             "/server": self._cmd_server,
             "/clear": self._cmd_clear,
@@ -769,6 +774,39 @@ class InteractiveShell:
             "[green]✓ Resumed chat #{}.[/green]{} Type a message to continue.".format(
                 chat_id, truncated
             )
+        )
+
+    def _cmd_upload(self, args: List[str]) -> None:
+        self._require_api_connection()
+        if not args:
+            self.console.print(
+                "[yellow]Usage: /upload <path> [path…][/yellow]\n"
+                "[dim]Logs, CSV, JSON, YAML and images. 10 MB each.[/dim]"
+            )
+            return
+        if self.chat_id is None:
+            self.console.print(
+                "[yellow]Send a message first — files attach to a chat, and this one "
+                "has not started yet.[/yellow]"
+            )
+            return
+
+        with self.console.status("[cyan]Uploading…[/cyan]", spinner="dots"):
+            payload = self.client.upload_chat_files(self.chat_id, args)
+
+        uploaded = payload.get("files") or []
+        if not uploaded:
+            self.console.print("[yellow]Nothing was uploaded.[/yellow]")
+            return
+        for item in uploaded:
+            size_kb = (item.get("size") or 0) / 1024
+            self.console.print(
+                "[green]Attached[/green] {} [dim]({:.1f} KB)[/dim]".format(
+                    item.get("name", "file"), size_kb
+                )
+            )
+        self.console.print(
+            "[dim]Ask about it by name — the agent reads attached files.[/dim]"
         )
 
     def _cmd_servers(self, args: List[str]) -> None:

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -16,6 +16,7 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import prompt as secure_prompt
 from prompt_toolkit.styles import Style
 from rich.console import Console
+from rich.markup import escape
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.rule import Rule
@@ -422,7 +423,7 @@ class InteractiveShell:
 
     def _upload_dropped(self, paths: List[str]) -> None:
         if self.chat_id is None:
-            names = ", ".join(Path(path).name for path in paths)
+            names = escape(", ".join(Path(path).name for path in paths))
             self.console.print(
                 "[yellow]Got {} — send a message to start the chat, then drop it "
                 "again or run /upload.[/yellow]".format(names)
@@ -854,7 +855,7 @@ class InteractiveShell:
             size_kb = (item.get("size") or 0) / 1024
             self.console.print(
                 "[green]Attached[/green] {} [dim]({:.1f} KB)[/dim]".format(
-                    item.get("name", "file"), size_kb
+                    escape(str(item.get("name", "file"))), size_kb
                 )
             )
         self.console.print(
@@ -1645,8 +1646,11 @@ class InteractiveShell:
         )
         status = " ({})".format(error.status_code) if error.status_code else ""
         self._print_section(title, style="red")
+        # A server message or a filename can contain square brackets, and Rich
+        # RAISES MarkupError on an unbalanced tag rather than rendering it — so
+        # an unescaped error message can crash the error handler itself.
         self.console.print("{}{}\n\n[dim]{}\nThe command line is still active.[/dim]\n".format(
-            error, status, guidance
+            escape(str(error)), status, guidance
         ))
 
     @staticmethod

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -1,7 +1,9 @@
 """Skyportal authentication and headless-agent API client."""
 
 import json
+import mimetypes
 import os
+import secrets
 import socket
 import tempfile
 import time
@@ -17,6 +19,29 @@ from skyportalai import _env
 from skyportalai._client import DEFAULT_BASE_URL, MARKETING_BASE_URL, _validate_base_url, normalize_base_url
 from skyportalai._exceptions import SkyportalError
 from skyportalai._version import __version__
+
+# Mirrors MAX_FILE_SIZE_BYTES on the server; checked here so an oversized file is
+# refused before it is read into memory.
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+
+def _encode_multipart(parts: List[Any]) -> Any:
+    """Build a multipart/form-data body. urllib has no multipart support of its own."""
+    boundary = "----SkyportalBoundary" + secrets.token_hex(16)
+    buffer = bytearray()
+    for filename, content, content_type in parts:
+        # The filename is quoted into a header, so a quote or newline in it would
+        # let a crafted name inject headers or a second part.
+        safe_name = filename.replace('"', "").replace("\r", "").replace("\n", "")
+        buffer += ("--" + boundary + "\r\n").encode()
+        buffer += (
+            'Content-Disposition: form-data; name="files"; filename="{}"\r\n'.format(safe_name)
+        ).encode()
+        buffer += ("Content-Type: " + content_type + "\r\n\r\n").encode()
+        buffer += content
+        buffer += b"\r\n"
+    buffer += ("--" + boundary + "--\r\n").encode()
+    return bytes(buffer), "multipart/form-data; boundary=" + boundary
 
 PRODUCTION_MARKETING_URL = MARKETING_BASE_URL
 PRODUCTION_APP_URL = DEFAULT_BASE_URL
@@ -444,6 +469,35 @@ class SkyportalClient:
             json_body={"message": message},
         )
 
+    def upload_chat_files(self, chat_id: int, paths: List[str]) -> Dict[str, Any]:
+        """Attach files to a chat. Logs, CSV, JSON, YAML and images all work."""
+        parts = []
+        for raw_path in paths:
+            path = Path(raw_path).expanduser()
+            if not path.is_file():
+                raise PortalError("No such file: {}".format(raw_path))
+            size = path.stat().st_size
+            if size == 0:
+                raise PortalError("{} is empty".format(path.name))
+            # Checked before reading so a huge file is refused rather than loaded
+            # into memory only to be rejected by the server.
+            if size > MAX_UPLOAD_BYTES:
+                raise PortalError(
+                    "{} is {:.0f} MB; the limit is {} MB".format(
+                        path.name, size / 1e6, MAX_UPLOAD_BYTES // 1_000_000
+                    )
+                )
+            guessed = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+            parts.append((path.name, path.read_bytes(), guessed))
+
+        body, content_type = _encode_multipart(parts)
+        return self._request(
+            "POST",
+            "/api/v1/agent/chat/{}/upload/".format(chat_id),
+            body=body,
+            content_type=content_type,
+        )
+
     def chat_status(
         self,
         chat_id: int,
@@ -837,13 +891,18 @@ class SkyportalClient:
         json_body: Optional[Dict[str, Any]] = None,
         authenticated: bool = True,
         bearer_token: Optional[str] = None,
+        body: Optional[bytes] = None,
+        content_type: Optional[str] = None,
     ) -> Any:
         headers = {
             "Accept": "application/json",
             "User-Agent": CLI_USER_AGENT,
         }
         data = None
-        if json_body is not None:
+        if body is not None:
+            data = body
+            headers["Content-Type"] = content_type or "application/octet-stream"
+        elif json_body is not None:
             data = json.dumps(json_body).encode()
             headers["Content-Type"] = "application/json"
         if bearer_token:

--- a/tests/test_shell_upload.py
+++ b/tests/test_shell_upload.py
@@ -181,6 +181,42 @@ class TestUploadClient:
         assert sent["content_type"].startswith("multipart/form-data")
         assert b"latency_ms=118" in sent["body"]
 
+    @pytest.mark.parametrize(
+        "filename, content",
+        [
+            ("metrics.csv", "timestamp,requests,p95_ms\n2026-09-02T12:00:00Z,3410,118\n"),
+            ("vllm.log", "2026-09-02 12:00:01 INFO throughput 42.1 tokens/s\n"),
+            ("notes.txt", "Restarted the pod at 12:05.\n"),
+            # Real logs are often bare names. mimetypes guesses octet-stream for
+            # these; the server decides by decoding, not by the declared type, so
+            # this must keep being sent rather than refused here.
+            ("syslog", "Sep  2 12:00:01 host kernel: oom-killer invoked\n"),
+        ],
+    )
+    def test_the_formats_people_actually_upload(self, tmp_path, monkeypatch, filename, content):
+        client, sent = self._client(tmp_path, monkeypatch)
+        target = tmp_path / filename
+        target.write_text(content)
+
+        client.upload_chat_files(7, [str(target)])
+
+        body = sent["body"].decode()
+        assert 'filename="{}"'.format(filename) in body
+        assert content.strip() in body
+
+    def test_several_files_dropped_together_all_reach_the_body(self, tmp_path, monkeypatch):
+        client, sent = self._client(tmp_path, monkeypatch)
+        names = ["metrics.csv", "vllm.log", "notes.txt"]
+        for name in names:
+            (tmp_path / name).write_text("content of {}\n".format(name))
+
+        client.upload_chat_files(7, [str(tmp_path / name) for name in names])
+
+        body = sent["body"].decode()
+        for name in names:
+            assert 'filename="{}"'.format(name) in body
+            assert "content of {}".format(name) in body
+
 
 class TestDroppedFiles:
     """Dropping a file on a running terminal types its path at the prompt.

--- a/tests/test_shell_upload.py
+++ b/tests/test_shell_upload.py
@@ -180,3 +180,152 @@ class TestUploadClient:
         assert sent["path"] == "/api/v1/agent/chat/7/upload/"
         assert sent["content_type"].startswith("multipart/form-data")
         assert b"latency_ms=118" in sent["body"]
+
+
+class TestDroppedFiles:
+    """Dropping a file on a running terminal types its path at the prompt.
+
+    Driven through _route, the real entry point, because the routing is the
+    thing under test: a quoted path does not start with "/" and never reached
+    the command dispatcher at all.
+    """
+
+    @pytest.fixture
+    def routed(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        sent = []
+        instance._send_prompt = sent.append
+        log = tmp_path / "vllm.log"
+        log.write_text("latency_ms=118\n")
+        return instance, client, out, sent, log
+
+    def test_a_plain_dropped_path_uploads(self, routed):
+        instance, client, _, sent, log = routed
+
+        instance._route(str(log))
+
+        assert client.uploads == [(42, [str(log)])]
+        assert sent == []
+
+    def test_a_backslash_escaped_path_uploads(self, routed, tmp_path):
+        instance, client, _, _, _ = routed
+        folder = tmp_path / "my logs"
+        folder.mkdir()
+        log = folder / "vllm.log"
+        log.write_text("x\n")
+
+        instance._route(str(log).replace(" ", "\\ "))
+
+        assert client.uploads == [(42, [str(log)])]
+
+    def test_a_quoted_path_uploads(self, routed, tmp_path):
+        instance, client, _, sent, _ = routed
+        folder = tmp_path / "my logs"
+        folder.mkdir()
+        log = folder / "vllm.log"
+        log.write_text("x\n")
+
+        instance._route("'{}'".format(log))
+
+        assert client.uploads == [(42, [str(log)])]
+        assert sent == []
+
+    def test_two_dropped_files_upload_together(self, routed, tmp_path):
+        instance, client, _, _, _ = routed
+        first = tmp_path / "a.log"
+        first.write_text("a\n")
+        second = tmp_path / "b.csv"
+        second.write_text("b\n")
+
+        instance._route("{} {}".format(first, second))
+
+        assert client.uploads == [(42, [str(first), str(second)])]
+
+    def test_a_file_uri_uploads(self, routed):
+        instance, client, _, _, log = routed
+
+        instance._route("file://{}".format(log))
+
+        assert client.uploads == [(42, [str(log)])]
+
+    def test_a_trailing_space_does_not_break_the_drop(self, routed):
+        instance, client, _, _, log = routed
+
+        instance._route("{} ".format(log))
+
+        assert client.uploads == [(42, [str(log)])]
+
+    def test_a_drop_before_the_chat_starts_says_so(self, routed):
+        instance, client, out, _, log = routed
+        instance.chat_id = None
+
+        instance._route(str(log))
+
+        assert client.uploads == []
+        assert "vllm.log" in out.getvalue()
+        assert "send a message" in out.getvalue().lower()
+
+    def test_a_real_command_still_dispatches(self, routed):
+        instance, client, out, sent, _ = routed
+
+        instance._route("/help")
+
+        assert client.uploads == []
+        assert sent == []
+        assert "Skyportal commands" in out.getvalue()
+
+    def test_upload_with_an_argument_still_reaches_its_handler(self, routed):
+        instance, client, _, _, log = routed
+
+        instance._route("/upload {}".format(log))
+
+        assert client.uploads == [(42, [str(log)])]
+
+    def test_an_unknown_slash_command_is_still_unknown(self, routed):
+        instance, client, out, sent, _ = routed
+
+        instance._route("/nope/not/a/file")
+
+        assert client.uploads == []
+        assert sent == []
+        assert "Unknown command" in out.getvalue()
+
+    def test_a_bare_filename_is_a_message_not_an_upload(self, routed):
+        instance, client, _, sent, _ = routed
+
+        instance._route("check vllm.log for errors")
+
+        assert client.uploads == []
+        assert sent == ["check vllm.log for errors"]
+
+    def test_a_relative_path_that_exists_is_still_a_message(self, routed, tmp_path, monkeypatch):
+        """A drop always types an ABSOLUTE path, so a relative one is someone typing.
+
+        Without the is_absolute() guard, running the shell from a directory that
+        happens to contain vllm.log would turn the message "vllm.log" into an
+        upload.
+        """
+        instance, client, _, sent, _ = routed
+        monkeypatch.chdir(tmp_path)
+
+        instance._route("vllm.log")
+
+        assert client.uploads == []
+        assert sent == ["vllm.log"]
+
+    def test_an_apostrophe_in_a_message_is_not_a_parse_error(self, routed):
+        instance, client, out, sent, _ = routed
+
+        instance._route("don't restart it")
+
+        assert client.uploads == []
+        assert sent == ["don't restart it"]
+        assert "Could not parse" not in out.getvalue()
+
+    def test_a_dropped_directory_is_not_an_upload(self, routed, tmp_path):
+        instance, client, _, _, _ = routed
+
+        instance._route(str(tmp_path))
+
+        assert client.uploads == []

--- a/tests/test_shell_upload.py
+++ b/tests/test_shell_upload.py
@@ -365,3 +365,65 @@ class TestDroppedFiles:
         instance._route(str(tmp_path))
 
         assert client.uploads == []
+
+
+class TestMarkupSafety:
+    """A filename is untrusted text on its way through Rich's markup parser.
+
+    Rich RAISES MarkupError on an unbalanced closing tag rather than rendering
+    it, so an unescaped name does not just restyle the line — it crashes the
+    handler printing it.
+    """
+
+    EVIL = "report[/green][bold red]INJECTED[/bold red].log"
+
+    def test_a_bracketed_filename_from_the_server_does_not_crash(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = {"success": True, "files": [{"name": self.EVIL, "size": 1024}]}
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        text = out.getvalue()
+        assert "INJECTED" in text
+        assert "Attached" in text
+
+    def test_a_bracketed_filename_is_shown_literally(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = {"success": True, "files": [{"name": self.EVIL, "size": 1024}]}
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        assert "[bold red]" in out.getvalue()
+
+    def test_a_bracketed_name_in_an_error_does_not_crash(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.error = PortalError("{} is empty".format(self.EVIL))
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        try:
+            instance._cmd_upload([str(log)])
+        except PortalError as exc:
+            instance._show_portal_error(exc)
+
+        assert "INJECTED" in out.getvalue()
+
+    def test_a_bracketed_name_in_the_no_chat_notice_does_not_crash(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = None
+        # No slash: it must be a name the filesystem accepts, while still
+        # carrying the brackets Rich would try to parse.
+        odd = tmp_path / "weird[dim]name.log"
+        odd.write_text("x\n")
+
+        instance._route(str(odd))
+
+        assert "weird" in out.getvalue()
+        assert client.uploads == []

--- a/tests/test_shell_upload.py
+++ b/tests/test_shell_upload.py
@@ -1,0 +1,182 @@
+"""/upload attaches logs and exports to the current chat (skyportal-website#3432)."""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from skyportalai.shell import portal
+from skyportalai.shell.interactive import COMMANDS, InteractiveShell
+from skyportalai.shell.portal import PortalError
+
+
+class FakeClient:
+    base_url = "https://app.skyportal.ai"
+
+    def __init__(self):
+        self.uploads = []
+        self.response = {"success": True, "files": [{"name": "vllm.log", "size": 2048}]}
+        self.error = None
+
+    def is_authenticated(self):
+        return True
+
+    def upload_chat_files(self, chat_id, paths):
+        if self.error:
+            raise self.error
+        self.uploads.append((chat_id, list(paths)))
+        return self.response
+
+
+@pytest.fixture
+def shell(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKYPORTALAI_LAST_CHAT_PATH", str(tmp_path / "last_chat"))
+    out = StringIO()
+    console = Console(file=out, width=160, force_terminal=False)
+    client = FakeClient()
+    instance = InteractiveShell(
+        console=console,
+        client_factory=lambda: client,
+        session=object(),
+        token_prompt=lambda _prompt: "",
+    )
+    return instance, client, out
+
+
+def test_upload_sends_the_paths_to_the_active_chat(shell, tmp_path):
+    instance, client, out = shell
+    instance.chat_id = 42
+    log = tmp_path / "vllm.log"
+    log.write_text("latency_ms=118\n")
+
+    instance._cmd_upload([str(log)])
+
+    assert client.uploads == [(42, [str(log)])]
+    assert "Attached" in out.getvalue()
+    assert "vllm.log" in out.getvalue()
+
+
+def test_upload_without_a_chat_explains_rather_than_failing(shell, tmp_path):
+    instance, client, out = shell
+    instance.chat_id = None
+    log = tmp_path / "vllm.log"
+    log.write_text("x\n")
+
+    instance._cmd_upload([str(log)])
+
+    assert client.uploads == []
+    assert "Send a message first" in out.getvalue()
+
+
+def test_upload_without_arguments_shows_usage(shell):
+    instance, client, out = shell
+    instance.chat_id = 42
+
+    instance._cmd_upload([])
+
+    assert client.uploads == []
+    assert "/upload" in out.getvalue()
+
+
+def test_upload_is_dispatchable_and_documented(shell):
+    instance, _, _ = shell
+
+    assert instance._handlers["/upload"] == instance._cmd_upload
+    assert "/upload" in COMMANDS
+
+
+class TestMultipartEncoding:
+    def test_body_is_parseable_multipart(self):
+        body, content_type = portal._encode_multipart(
+            [("vllm.log", b"latency_ms=118\n", "text/plain")]
+        )
+
+        assert content_type.startswith("multipart/form-data; boundary=")
+        boundary = content_type.split("boundary=", 1)[1]
+        text = body.decode()
+        assert text.startswith("--" + boundary)
+        assert text.rstrip().endswith("--" + boundary + "--")
+        assert 'name="files"; filename="vllm.log"' in text
+        assert "latency_ms=118" in text
+
+    def test_each_file_becomes_its_own_part(self):
+        body, content_type = portal._encode_multipart(
+            [("a.log", b"one", "text/plain"), ("b.csv", b"two", "text/csv")]
+        )
+        boundary = content_type.split("boundary=", 1)[1]
+
+        assert body.decode().count("--" + boundary) == 3  # two parts + terminator
+        assert 'filename="a.log"' in body.decode()
+        assert 'filename="b.csv"' in body.decode()
+
+    def test_a_filename_cannot_inject_headers(self):
+        body, _ = portal._encode_multipart(
+            [('evil"\r\nX-Injected: yes\r\n\r\nbad.log', b"x", "text/plain")]
+        )
+
+        assert "X-Injected: yes\r\n" not in body.decode().replace(
+            'filename="evilX-Injected: yesbad.log"', ""
+        )
+        assert body.decode().count("Content-Disposition") == 1
+
+    def test_boundary_is_not_reused_between_calls(self):
+        _, first = portal._encode_multipart([("a", b"x", "text/plain")])
+        _, second = portal._encode_multipart([("a", b"x", "text/plain")])
+
+        assert first != second
+
+
+class TestUploadClient:
+    def _client(self, tmp_path, monkeypatch):
+        client = portal.SkyportalClient.__new__(portal.SkyportalClient)
+        client.base_url = "https://example.invalid"
+        sent = {}
+
+        def fake_request(method, path, **kwargs):
+            sent["method"] = method
+            sent["path"] = path
+            sent.update(kwargs)
+            return {"success": True, "files": []}
+
+        client._request = fake_request
+        return client, sent
+
+    def test_missing_file_is_refused_before_any_request(self, tmp_path, monkeypatch):
+        client, sent = self._client(tmp_path, monkeypatch)
+
+        with pytest.raises(PortalError, match="No such file"):
+            client.upload_chat_files(1, [str(tmp_path / "absent.log")])
+
+        assert sent == {}
+
+    def test_empty_file_is_refused(self, tmp_path, monkeypatch):
+        client, sent = self._client(tmp_path, monkeypatch)
+        empty = tmp_path / "empty.log"
+        empty.write_bytes(b"")
+
+        with pytest.raises(PortalError, match="empty"):
+            client.upload_chat_files(1, [str(empty)])
+
+        assert sent == {}
+
+    def test_oversized_file_is_refused_without_reading_it(self, tmp_path, monkeypatch):
+        client, sent = self._client(tmp_path, monkeypatch)
+        big = tmp_path / "big.log"
+        big.write_bytes(b"x" * (portal.MAX_UPLOAD_BYTES + 1))
+
+        with pytest.raises(PortalError, match="limit is 10 MB"):
+            client.upload_chat_files(1, [str(big)])
+
+        assert sent == {}
+
+    def test_a_good_file_posts_multipart_to_the_upload_route(self, tmp_path, monkeypatch):
+        client, sent = self._client(tmp_path, monkeypatch)
+        log = tmp_path / "vllm.log"
+        log.write_text("latency_ms=118\n")
+
+        client.upload_chat_files(7, [str(log)])
+
+        assert sent["method"] == "POST"
+        assert sent["path"] == "/api/v1/agent/chat/7/upload/"
+        assert sent["content_type"].startswith("multipart/form-data")
+        assert b"latency_ms=118" in sent["body"]


### PR DESCRIPTION
Adds `/upload <path> [path…]` to the interactive shell, so you can hand the agent a log instead of pasting it.

Client half of **SkyportalAi/skyportal-website#3432**. **Depends on skyportal-website#3434**, which adds the `/api/v1/agent/chat/<id>/upload/` route this posts to — merge that first, or `/upload` gets a 404.

```
skyportal> what's wrong with the inference server?
skyportal> /upload ~/logs/vllm.log
Attached vllm.log (412.0 KB)
Ask about it by name — the agent reads attached files.
skyportal> what error is repeating in vllm.log?
```

## Dropping the file on the terminal works too

`/upload` only helps if you know it exists. Dragging the file onto the window is what people actually reach for — and a terminal implements that by **typing the path at the cursor**, so a drop arrives as an ordinary line of input.

```
skyportal> what's wrong with the inference server?
skyportal> /Users/sfloris/logs/vllm.log        ← dragged, not typed
Attached vllm.log (412.0 KB)
```

Routing moved into `_route()`, which asks *"is this line nothing but existing absolute paths?"* **before** anything else. Order matters and is the subtle part: the check cannot sit behind the `startswith("/")` test, because terminals that **quote** a path containing spaces (GNOME Terminal, Kitty, WezTerm) produce a line starting with `'`, which would have gone to the agent as a chat message. iTerm2 and Terminal.app backslash-escape instead — so that bug would never have appeared on a Mac.

Handled: both quoting styles, several files at once, a trailing space, and `file://` URIs.

**What keeps it from eating input:** every token must be an *absolute* path to an *existing file*.

| Input | Goes to |
|---|---|
| `/Users/…/vllm.log` | upload |
| `/upload /Users/…/a.log` | the `/upload` handler (`/upload` isn't a file) |
| `/help` | the command dispatcher |
| `vllm.log` | the agent — even from a directory containing one |
| `don't restart it` | the agent (an apostrophe is an unbalanced quote; it falls through rather than erroring) |

A drop always types an absolute path, so a relative one is someone typing.

## Why the client needed real work

The shell's client is hand-rolled `urllib`, and `_request` only ever sent JSON — it `json.dumps`ed the body and set `Content-Type: application/json`. A file upload is `multipart/form-data`, which urllib has no support for, so this adds:

- `_encode_multipart(parts) -> (body, content_type)` — builds the body by hand with a random boundary per call.
- A raw-body path on `_request` (`body=` / `content_type=`) beside the existing JSON one.
- `upload_chat_files(chat_id, paths)` on the client.

## Security

**A filename is interpolated into a `Content-Disposition` header**, so quotes and CRLF are stripped from it. Without that, a crafted name like `evil"\r\nX-Injected: yes\r\n\r\n` could inject a header or open a second part. There's a test for exactly that string.

Boundaries come from `secrets.token_hex(16)` and are per-call, so a body cannot be split by content that happens to match a previous boundary.

Secrets in the file are redacted **server-side before storage** (that's #3434's half) — the CLI does not need to and does not try to.

## Pre-flight refusals

Existence, emptiness and size are checked **before the file is read**, so a 2 GB log is refused with a sentence rather than being loaded into memory to be rejected by the server. `MAX_UPLOAD_BYTES` mirrors the server's limit.

## `/upload` needs a chat

The shell only has a `chat_id` once a turn has started. Rather than silently create a chat as a side effect of attaching a file, `/upload` before the first message says so and does nothing.

## Testing

26 new tests in `tests/test_shell_upload.py`; **full suite 598 passed, 0 failures**. The drop tests drive `_route`, not `_cmd_upload`, since the routing is the thing at issue.

The cross-repo contract was verified directly rather than assumed: a body from this encoder was fed to the **real Django request parser** from the server repo, which returned two files with the right names and bytes. That's the failure a unit test on either side alone would miss.

Revert-verified, three ways:

| Reverted | What fails |
|---|---|
| filename sanitisation | `test_a_filename_cannot_inject_headers` |
| drop check moved behind the `/` test | the quoted-path and `file://` cases |
| `is_absolute()` guard | the message `vllm.log` becomes an upload |

That middle row is worth noting: my first 25 tests all passed with the `is_absolute()` guard removed, which meant none of them tested it. The 26th was written specifically to catch it.

**A real drag cannot be automated**, so this is tested against the byte sequences each terminal family types. Worth one manual drag on iTerm2 before merge.

Note: `tests/test_agent_mlflow_rest.py` fails to collect on a clean `origin/main` too (`requests_mock` not installed); unrelated to this change.

## Scope

Interactive shell only, per the requirement that this lives in the chat interface. The Typer surface (`skyportalai chat …`) goes through a separate `requests`-based SDK client and does **not** get `upload` here — worth a follow-up if the scriptable path needs it.

Touches `shell/interactive.py`, which Sean's rename ticket (skyportal-website#3394) also covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbFY26qHgPpJUu6WTc5Ce2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `/upload <path>` support for attaching one or more files to active chats.
  - Supports terminal drag-and-drop, quoted paths, `file://` URIs, and multiple files.
  - Displays uploaded filenames and sizes, with references available in chat messages.
  - Enforces a 10 MB per-file limit and supports common file formats.

- **Bug Fixes**
  - Sensitive values are now redacted from server-side logs.
  - Filenames and error messages containing special markup now display correctly.

- **Documentation**
  - Updated the unreleased changelog with upload usage, limits, supported formats, and drag-and-drop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->