### PR TITLE
fix: Skyportal brand spelling in user facing text and docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to skyportalai
 
-Thank you for helping improve the SkyPortal Python SDK, command-line clients,
+Thank you for helping improve the Skyportal Python SDK, command-line clients,
 and observability agent.
 
 ## Report an issue

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 SkyPortal
+Copyright (c) 2026 Skyportal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Run `skyportalai --help` for the complete command reference.
 ## Kubernetes clusters
 
 Connect a cluster with its kubeconfig. The CLI sends the credential only to the
-authenticated SkyPortal API, where the same validation and encrypted storage as
+authenticated Skyportal API, where the same validation and encrypted storage as
 the web application are used; kubeconfigs are never returned by lifecycle APIs.
 
 ```bash
@@ -184,7 +184,7 @@ skyportalai kubernetes disconnect 17
 
 ## Ansible playbooks
 
-Store validated playbooks in SkyPortal and reuse them across account-owned SSH
+Store validated playbooks in Skyportal and reuse them across account-owned SSH
 targets. List responses omit YAML bodies; `show` retrieves one playbook when
 you need to inspect or edit it.
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,7 +1,7 @@
 # Observability agent
 
 `skyportalai-agent` discovers local Weights & Biases and MLflow runs, stores new
-run batches in a bounded disk queue, and sends them to SkyPortal. It is intended
+run batches in a bounded disk queue, and sends them to Skyportal. It is intended
 for a dedicated host or container with only the experiment volumes it needs.
 
 ## Install and run
@@ -20,7 +20,7 @@ a final delivery attempt.
 | Environment variable | Default | Description |
 |---|---:|---|
 | `SKYPORTALAI_AGENT_TOKEN` | required | Host-bound observability upload token |
-| `SKYPORTALAI_BASE_URL` | `https://app.skyportal.ai` | SkyPortal API root |
+| `SKYPORTALAI_BASE_URL` | `https://app.skyportal.ai` | Skyportal API root |
 | `SKYPORTALAI_AGENT_INTERVAL_SECONDS` | `60` | Seconds between scans |
 | `SKYPORTALAI_AGENT_STATE_DIR` | `/var/lib/skyportal-agent` | Catalog and delivery spool |
 | `SKYPORTALAI_AGENT_QUEUE_MAX_BATCHES` | `1000` | Maximum on-disk batches |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -166,7 +166,7 @@ Repointing the CLI at a different instance leaves the saved key behind, and a
 key is only valid on the instance that issued it:
 
 ```
-Error: Stored credentials belong to another SkyPortal deployment
+Error: Stored credentials belong to another Skyportal deployment
 (http://localhost:8000), but the selected base URL is https://app.skyportal.ai.
 Run 'skyportalai logout' to clear them (/home/you/.skyportalai/credentials.json),
 or keep them by running 'skyportalai config set --base-url http://localhost:8000'.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "skyportalai"
 version = "0.2.2"
-description = "Official Python SDK and command-line client for the SkyPortal API"
-authors = [{ name = "SkyPortal", email = "tech@skyportal.ai" }]
+description = "Official Python SDK and command-line client for the Skyportal API"
+authors = [{ name = "Skyportal", email = "tech@skyportal.ai" }]
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -38,7 +38,7 @@ skyportalai-agent = "skyportalai.agent.__main__:main"
 
 [project.urls]
 Homepage = "https://skyportal.ai"
-Documentation = "https://github.com/SkyportalAi/skyportalai#readme"
+Documentation = "https://docs.skyportal.ai"
 Repository = "https://github.com/SkyportalAi/skyportalai"
 Issues = "https://github.com/SkyportalAi/skyportalai/issues"
 

--- a/skyportalai/__init__.py
+++ b/skyportalai/__init__.py
@@ -1,4 +1,4 @@
-"""skyportalai — the official Python SDK for the SkyPortal API."""
+"""skyportalai — the official Python SDK for the Skyportal API."""
 from ._client import Skyportal
 from ._exceptions import (
     APIConnectionError,

--- a/skyportalai/_client.py
+++ b/skyportalai/_client.py
@@ -1,4 +1,4 @@
-"""The SkyPortal API client."""
+"""The Skyportal API client."""
 from __future__ import annotations
 
 import time
@@ -146,7 +146,7 @@ def _check_base_url(base_url: str) -> None:
 
 
 class Skyportal:
-    """Synchronous SkyPortal API client.
+    """Synchronous Skyportal API client.
 
     Args:
         api_key: Bearer credential. Falls back to ``SKYPORTALAI_API_KEY``.

--- a/skyportalai/_exceptions.py
+++ b/skyportalai/_exceptions.py
@@ -1,4 +1,4 @@
-"""Exception tree for the SkyPortal SDK.
+"""Exception tree for the Skyportal SDK.
 
 Callers only ever see ``skyportalai`` exceptions — a raw ``requests`` exception
 never escapes the client.

--- a/skyportalai/agent/__init__.py
+++ b/skyportalai/agent/__init__.py
@@ -1,7 +1,7 @@
-"""SkyPortal Kubernetes observability agent.
+"""Skyportal Kubernetes observability agent.
 
 Containerizes the proven experiment scanners so a pod can discover MLflow/WandB
-runs on a mounted volume and push them to SkyPortal. Daemon dependencies live
+runs on a mounted volume and push them to Skyportal. Daemon dependencies live
 behind the ``skyportalai[agent]`` extra; the plain SDK is unaffected.
 """
 

--- a/skyportalai/agent/config.py
+++ b/skyportalai/agent/config.py
@@ -69,7 +69,7 @@ def _parse_path(value: str | None) -> Path | None:
 
 @dataclass(frozen=True)
 class AgentConfig:
-    """Typed configuration for the SkyPortal observability agent."""
+    """Typed configuration for the Skyportal observability agent."""
 
     token: str
     base_url: str = DEFAULT_BASE_URL

--- a/skyportalai/cli/__init__.py
+++ b/skyportalai/cli/__init__.py
@@ -1,4 +1,4 @@
-"""Public command-line interface for the SkyPortal SDK."""
+"""Public command-line interface for the Skyportal SDK."""
 
 
 def main() -> None:

--- a/skyportalai/cli/config.py
+++ b/skyportalai/cli/config.py
@@ -50,7 +50,7 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
     credentials, credential_conflict = _read_credentials(credentials_path)
     portal = config.get("portal", {})
     if not isinstance(portal, dict):
-        raise SkyportalError(f"Invalid SkyPortal configuration in {config_path}: 'portal' must be a mapping.")
+        raise SkyportalError(f"Invalid Skyportal configuration in {config_path}: 'portal' must be a mapping.")
 
     stored_url = credentials.get("base_url")
     effective_url, url_origin = _select_base_url(
@@ -80,7 +80,7 @@ def resolve_settings(*, base_url: str | None = None) -> CLISettings:
         stored_normalized = normalize_base_url(str(stored_url)) if stored_url else None
         if stored_normalized and stored_normalized != effective_url:
             credential_conflict = (
-                f"Stored credentials belong to another SkyPortal deployment "
+                f"Stored credentials belong to another Skyportal deployment "
                 f"({stored_normalized}), but the selected base URL is {effective_url}. "
                 f"Run 'skyportalai logout' to clear them ({credentials_path}), "
                 f"or keep them by {_keep_credentials_advice(url_origin, stored_normalized)}."
@@ -136,7 +136,7 @@ def save_connection_config(*, base_url: str | None, timeout: float | None) -> Pa
     config = _read_mapping(path, "configuration", yaml.safe_load)
     portal = config.setdefault("portal", {})
     if not isinstance(portal, dict):
-        raise SkyportalError(f"Invalid SkyPortal configuration in {path}: 'portal' must be a mapping.")
+        raise SkyportalError(f"Invalid Skyportal configuration in {path}: 'portal' must be a mapping.")
     if base_url is not None:
         portal["base_url"] = base_url.rstrip("/")
     if timeout is not None:
@@ -167,12 +167,12 @@ def _read_credentials(path: Path) -> tuple[dict[str, Any], str | None]:
         with path.open() as source:
             value = json.load(source) or {}
     except OSError as exc:
-        return {}, f"Could not read SkyPortal credentials from {path}: {exc}. Check the file's permissions."
+        return {}, f"Could not read Skyportal credentials from {path}: {exc}. Check the file's permissions."
     except ValueError as exc:
-        return {}, f"Invalid SkyPortal credentials in {path}: {exc}. Run 'skyportalai logout' to remove the file."
+        return {}, f"Invalid Skyportal credentials in {path}: {exc}. Run 'skyportalai logout' to remove the file."
     if not isinstance(value, dict):
         return {}, (
-            f"Invalid SkyPortal credentials in {path}: expected a mapping. "
+            f"Invalid Skyportal credentials in {path}: expected a mapping. "
             "Run 'skyportalai logout' to remove the file."
         )
     return value, None
@@ -185,7 +185,7 @@ def _read_mapping(path: Path, label: str, loader: Any) -> dict[str, Any]:
         with path.open() as source:
             value = loader(source) or {}
     except (OSError, ValueError, yaml.YAMLError) as exc:
-        raise SkyportalError(f"Could not read SkyPortal {label} from {path}: {exc}") from exc
+        raise SkyportalError(f"Could not read Skyportal {label} from {path}: {exc}") from exc
     if not isinstance(value, dict):
-        raise SkyportalError(f"Invalid SkyPortal {label} in {path}: expected a mapping.")
+        raise SkyportalError(f"Invalid Skyportal {label} in {path}: expected a mapping.")
     return value

--- a/skyportalai/cli/kubernetes.py
+++ b/skyportalai/cli/kubernetes.py
@@ -121,7 +121,7 @@ def disconnect(
         typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
     ] = False,
 ) -> None:
-    """Remove a Kubernetes cluster and its encrypted kubeconfig from SkyPortal."""
+    """Remove a Kubernetes cluster and its encrypted kubeconfig from Skyportal."""
     if not yes:
         if _state(context).output.json_mode:
             _state(context).output.failure("--yes is required when using --json mode")

--- a/skyportalai/cli/main.py
+++ b/skyportalai/cli/main.py
@@ -16,7 +16,7 @@ from .shell_commands import run_shell
 
 app = typer.Typer(
     name="skyportalai",
-    help="Drive the SkyPortal API and ops agent.",
+    help="Drive the Skyportal API and ops agent.",
     # Bare `skyportalai` drops into the interactive shell, matching the
     # behaviour the standalone `skyportal` command had before 0.2.0.
     invoke_without_command=True,
@@ -115,7 +115,7 @@ def set_config(
     state.settings = updated
     state.output.success(
         {"config_path": path, "base_url": updated.base_url, "timeout": updated.timeout},
-        human=f"Saved SkyPortal CLI configuration to {path}",
+        human=f"Saved Skyportal CLI configuration to {path}",
     )
 
 

--- a/skyportalai/resources/chat.py
+++ b/skyportalai/resources/chat.py
@@ -24,7 +24,7 @@ BUSY_STATUSES = frozenset({"processing", "uninitialized"})
 
 
 class ChatResource:
-    """``client.chat`` — drive the SkyPortal ops agent over REST.
+    """``client.chat`` — drive the Skyportal ops agent over REST.
 
     Every method takes the ``chat_id`` explicitly; ``create_chat()`` returns a
     bound :class:`~skyportalai.chat.Chat` handle so callers can chain

--- a/skyportalai/resources/kubernetes.py
+++ b/skyportalai/resources/kubernetes.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class KubernetesResource:
     """Connect, list, and disconnect Kubernetes clusters.
 
-    Kubeconfigs are sent only to the authenticated SkyPortal API, where the
+    Kubeconfigs are sent only to the authenticated Skyportal API, where the
     existing server-side validation and encrypted-storage path handles them.
     No lifecycle response returns kubeconfig credential material.
     """

--- a/skyportalai/types.py
+++ b/skyportalai/types.py
@@ -9,7 +9,7 @@ PermissionMode = Literal["ask", "autoapprove"]
 
 @dataclass(frozen=True)
 class User:
-    """A SkyPortal user.
+    """A Skyportal user.
 
     ``raw`` holds the full auth-check payload so new server fields (id, email…)
     are available immediately, before the SDK grows typed accessors for them.
@@ -25,7 +25,7 @@ class User:
 
 @dataclass(frozen=True)
 class KubernetesCluster:
-    """A Kubernetes cluster connected to the authenticated SkyPortal account."""
+    """A Kubernetes cluster connected to the authenticated Skyportal account."""
 
     id: int
     name: str

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -56,7 +56,7 @@ def test_credentials_are_scoped_to_the_selected_deployment(tmp_path, monkeypatch
     # the file and the recovery command, and a containment check for a URL is the
     # bug pattern CodeQL's py/incomplete-url-substring-sanitization looks for.
     assert settings.credential_conflict == (
-        "Stored credentials belong to another SkyPortal deployment (https://one.example), "
+        "Stored credentials belong to another Skyportal deployment (https://one.example), "
         "but the selected base URL is https://two.example. "
         f"Run 'skyportalai logout' to clear them ({credentials}), "
         "or keep them by unsetting SKYPORTALAI_BASE_URL."
@@ -72,7 +72,7 @@ def test_the_conflict_names_the_setting_that_actually_selected_the_url(tmp_path)
     settings = resolve_settings()
 
     assert settings.credential_conflict == (
-        "Stored credentials belong to another SkyPortal deployment (https://one.example), "
+        "Stored credentials belong to another Skyportal deployment (https://one.example), "
         "but the selected base URL is https://two.example. "
         f"Run 'skyportalai logout' to clear them ({credentials}), "
         "or keep them by running 'skyportalai config set --base-url https://one.example'."
@@ -86,7 +86,7 @@ def test_a_base_url_flag_is_not_fixable_by_editing_the_config(tmp_path):
     settings = resolve_settings(base_url="https://two.example")
 
     assert settings.credential_conflict == (
-        "Stored credentials belong to another SkyPortal deployment (https://one.example), "
+        "Stored credentials belong to another Skyportal deployment (https://one.example), "
         "but the selected base URL is https://two.example. "
         f"Run 'skyportalai logout' to clear them ({credentials}), "
         "or keep them by dropping --base-url."
@@ -113,7 +113,7 @@ def test_an_unparseable_credential_file_is_reported_not_raised(tmp_path):
     settings = resolve_settings()
 
     assert settings.api_key is None
-    assert settings.credential_conflict.startswith(f"Invalid SkyPortal credentials in {credentials}:")
+    assert settings.credential_conflict.startswith(f"Invalid Skyportal credentials in {credentials}:")
     assert settings.credential_conflict.endswith("Run 'skyportalai logout' to remove the file.")
 
 

--- a/tests/test_cli_logout_recovery.py
+++ b/tests/test_cli_logout_recovery.py
@@ -60,7 +60,7 @@ def test_a_command_needing_the_credential_reports_the_conflict_without_a_traceba
 
     assert result.exit_code == 1
     assert result.exception is None or isinstance(result.exception, SystemExit)
-    assert "another SkyPortal deployment" in result.output
+    assert "another Skyportal deployment" in result.output
     assert "skyportalai logout" in result.output
     assert str(credentials_path) in result.output
     assert credentials_path.exists()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -81,7 +81,7 @@ def test_config_set_and_human_target_output(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Saved SkyPortal CLI configuration" in result.stdout
+    assert "Saved Skyportal CLI configuration" in result.stdout
     assert "API target: https://portal.example" in result.output
     config = yaml.safe_load((tmp_path / "config.yaml").read_text())
     assert config["portal"] == {"base_url": "https://portal.example", "request_timeout": 15.0}


### PR DESCRIPTION
The brand is Skyportal, but SkyPortal appeared in user facing prose in 21 files: the PyPI summary and author name, the CLI help line and error strings, module and command docstrings that Typer and help() surface, the README (Kubernetes and Ansible sections), CONTRIBUTING, the agent docs and the license copyright line. This sweeps them all to Skyportal. Identifiers (skyportalai, SkyportalError, SkyportalAi org URLs) are unchanged.

Also points the PyPI Documentation project URL at https://docs.skyportal.ai instead of the readme anchor, so the docs link on the package page lands on the real docs before Tuesday's launch.

Verification: ruff check passes, 572 tests pass (string assertions updated in lockstep), and a fresh venv install of the built package was smoke tested with the quickstart flow.

https://claude.ai/code/session_01Pfyi5SL1F4DhVYNhyXRr7p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized product naming to “Skyportal” across guides, README content, API documentation, and deployment instructions.
  * Updated project metadata with the documentation URL: https://docs.skyportal.ai.
  * Aligned license and package descriptions with the updated branding.

* **User-Facing Messaging**
  * Standardized “Skyportal” capitalization in CLI help, status messages, and error messages.

* **Tests**
  * Updated expected CLI output to reflect the standardized branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->