### PR TITLE
feat(shell): report upload progress instead of blocking on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here. This project follows
 
 ## Unreleased
 
+### Changed
+
+- **`/upload` no longer holds the prompt while a file is stored.** The server now
+  accepts the bytes and processes them on a worker, so the shell reports
+  "Uploading", then "Ready" when the file is actually readable — or "Failed" with
+  the reason. It stops waiting after a short while rather than blocking on a
+  worker it cannot see; the server retries on its own. Requires a deployment with
+  `GET /api/v1/agent/chat/<id>/uploads/`.
+
 ### Added
 
 - **`/upload <path>` attaches a file to the chat.** Logs, CSV, JSON, YAML and

--- a/skyportalai/shell/interactive.py
+++ b/skyportalai/shell/interactive.py
@@ -52,6 +52,11 @@ class CommandInfo:
     description: str
 
 
+# Bounded: the server retries on its own, so a slow file is not an error and the
+# shell should hand the prompt back rather than wait on a worker it cannot see.
+UPLOAD_WAIT_SECONDS = 20.0
+UPLOAD_POLL_SECONDS = 1.0
+
 COMMANDS: Dict[str, CommandInfo] = {
     "/help": CommandInfo("/help", "Show commands and keyboard shortcuts"),
     "/login": CommandInfo("/login [--no-browser]", "Create an API key and connect this CLI"),
@@ -844,23 +849,76 @@ class InteractiveShell:
             )
             return
 
-        with self.console.status("[cyan]Uploading…[/cyan]", spinner="dots"):
+        with self.console.status("[cyan]Sending…[/cyan]", spinner="dots"):
             payload = self.client.upload_chat_files(self.chat_id, args)
 
         uploaded = payload.get("files") or []
         if not uploaded:
             self.console.print("[yellow]Nothing was uploaded.[/yellow]")
             return
+
+        # The server accepts the bytes and processes them on a worker, so a file is
+        # not readable the instant it is accepted. Say which state it is in rather
+        # than implying it is ready.
+        pending = [item for item in uploaded if item.get("status") == "pending"]
         for item in uploaded:
             size_kb = (item.get("size") or 0) / 1024
-            self.console.print(
-                "[green]Attached[/green] {} [dim]({:.1f} KB)[/dim]".format(
-                    escape(str(item.get("name", "file"))), size_kb
+            name = escape(str(item.get("name", "file")))
+            if item.get("status") == "failed":
+                reason = escape(str(item.get("error") or "processing failed"))
+                self.console.print("[red]Failed[/red] {} [dim]({})[/dim]".format(name, reason))
+            elif item.get("status") == "pending":
+                self.console.print(
+                    "[cyan]Uploading[/cyan] {} [dim]({:.1f} KB)[/dim]".format(name, size_kb)
                 )
-            )
+            else:
+                self.console.print(
+                    "[green]Attached[/green] {} [dim]({:.1f} KB)[/dim]".format(name, size_kb)
+                )
+
+        if pending:
+            self._await_uploads([item["id"] for item in pending if item.get("id")])
+
         self.console.print(
             "[dim]Ask about it by name — the agent reads attached files.[/dim]"
         )
+
+    def _await_uploads(self, upload_ids: List[str]) -> None:
+        """Report each file as it becomes readable, without holding the prompt open.
+
+        Bounded rather than indefinite: the server retries on its own, so a slow
+        file is not an error, and the shell should hand the prompt back rather than
+        wait for a worker it cannot see.
+        """
+        remaining = set(upload_ids)
+        deadline = time.time() + UPLOAD_WAIT_SECONDS
+        with self.console.status("[cyan]Processing…[/cyan]", spinner="dots"):
+            while remaining and time.time() < deadline:
+                time.sleep(UPLOAD_POLL_SECONDS)
+                try:
+                    statuses = self.client.chat_upload_status(self.chat_id, sorted(remaining))
+                except PortalError:
+                    return
+                for item in statuses.get("files") or []:
+                    upload_id = item.get("id")
+                    if upload_id not in remaining:
+                        continue
+                    status = item.get("status")
+                    name = escape(str(item.get("name", "file")))
+                    if status == "ready":
+                        remaining.discard(upload_id)
+                        self.console.print("[green]Ready[/green] {}".format(name))
+                    elif status == "failed":
+                        remaining.discard(upload_id)
+                        reason = escape(str(item.get("error") or "processing failed"))
+                        self.console.print(
+                            "[red]Failed[/red] {} [dim]({})[/dim]".format(name, reason)
+                        )
+
+        for _ in remaining:
+            self.console.print(
+                "[dim]Still processing — ask about the file in a moment.[/dim]"
+            )
 
     def _cmd_servers(self, args: List[str]) -> None:
         self._require_api_connection()

--- a/skyportalai/shell/portal.py
+++ b/skyportalai/shell/portal.py
@@ -469,6 +469,13 @@ class SkyportalClient:
             json_body={"message": message},
         )
 
+    def chat_upload_status(self, chat_id: int, upload_ids: List[str]) -> Dict[str, Any]:
+        """Where each attached file has got to. Empty ids means every file in the chat."""
+        path = "/api/v1/agent/chat/{}/uploads/".format(chat_id)
+        if upload_ids:
+            path += "?" + urlencode({"ids": ",".join(upload_ids)})
+        return self._request("GET", path)
+
     def upload_chat_files(self, chat_id: int, paths: List[str]) -> Dict[str, Any]:
         """Attach files to a chat. Logs, CSV, JSON, YAML and images all work."""
         parts = []

--- a/tests/test_shell_upload.py
+++ b/tests/test_shell_upload.py
@@ -17,6 +17,8 @@ class FakeClient:
         self.uploads = []
         self.response = {"success": True, "files": [{"name": "vllm.log", "size": 2048}]}
         self.error = None
+        self.statuses = []
+        self.status_error = None
 
     def is_authenticated(self):
         return True
@@ -26,6 +28,14 @@ class FakeClient:
             raise self.error
         self.uploads.append((chat_id, list(paths)))
         return self.response
+
+    def chat_upload_status(self, chat_id, upload_ids):
+        if self.status_error:
+            raise self.status_error
+        if not self.statuses:
+            return {"files": []}
+        # Repeat the last answer so a poll loop sees a stable state.
+        return self.statuses.pop(0) if len(self.statuses) > 1 else self.statuses[0]
 
 
 @pytest.fixture
@@ -427,3 +437,84 @@ class TestMarkupSafety:
 
         assert "weird" in out.getvalue()
         assert client.uploads == []
+
+
+class TestUploadStatusReporting:
+    """Uploading is accepted-then-processed, so the shell must say which state a
+    file is in rather than implying it is ready the moment it is accepted."""
+
+    def _pending(self, name="vllm.log", upload_id="u1"):
+        return {"success": True, "files": [
+            {"id": upload_id, "name": name, "size": 2048, "status": "pending"},
+        ]}
+
+    def test_an_accepted_file_is_reported_as_uploading_not_attached(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = self._pending()
+        client.statuses = [{"files": [{"id": "u1", "name": "vllm.log", "status": "ready"}]}]
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        text = out.getvalue()
+        assert "Uploading" in text
+        assert "Ready" in text
+
+    def test_a_file_that_fails_processing_says_why(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = self._pending()
+        client.statuses = [{"files": [
+            {"id": "u1", "name": "vllm.log", "status": "failed", "error": "storage unavailable"},
+        ]}]
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        text = out.getvalue()
+        assert "Failed" in text
+        assert "storage unavailable" in text
+
+    def test_a_slow_file_hands_the_prompt_back_rather_than_hanging(self, shell, tmp_path, monkeypatch):
+        import skyportalai.shell.interactive as interactive
+
+        monkeypatch.setattr(interactive, "UPLOAD_WAIT_SECONDS", 0.05)
+        monkeypatch.setattr(interactive, "UPLOAD_POLL_SECONDS", 0.01)
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = self._pending()
+        client.statuses = [{"files": [{"id": "u1", "name": "vllm.log", "status": "pending"}]}]
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        assert "Still processing" in out.getvalue()
+
+    def test_a_status_error_does_not_break_the_shell(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = self._pending()
+        client.status_error = PortalError("network down")
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        assert "Uploading" in out.getvalue()
+
+    def test_an_already_ready_file_is_reported_attached(self, shell, tmp_path):
+        instance, client, out = shell
+        instance.chat_id = 42
+        client.response = {"success": True, "files": [
+            {"id": "u1", "name": "vllm.log", "size": 2048, "status": "ready"},
+        ]}
+        log = tmp_path / "vllm.log"
+        log.write_text("x\n")
+
+        instance._cmd_upload([str(log)])
+
+        assert "Attached" in out.getvalue()


### PR DESCRIPTION
Client half of **SkyportalAi/skyportal-website#3474**. **Depends on #3478 merging** — it adds the status endpoint this polls.

The server now accepts a file and processes it on a worker, so printing "Attached vllm.log" the moment the POST returns is a lie: the bytes are staged, not readable, and the agent cannot answer about them yet.

```
skyportal> /upload ~/logs/vllm.log
Uploading vllm.log (412.0 KB)
Ready vllm.log
Ask about it by name — the agent reads attached files.
```

Three states, and each says something true:

| | |
|---|---|
| `Uploading` | accepted and staged; not readable yet |
| `Ready` | the redacted object exists and the agent can read it |
| `Failed` | processing gave up, with the reason |

## It reports, it does not block

`_await_uploads` polls the new `GET /api/v1/agent/chat/<id>/uploads/?ids=…` and prints each file as it lands — then **stops after ~20s and hands the prompt back**. The server retries on its own, so a slow file is not an error someone should sit through, and the shell should not wait on a worker it cannot see. If it times out you get *"Still processing — ask about the file in a moment."*

A failed status poll is not fatal either: the file is already accepted, so the shell says so and moves on rather than surfacing a network error for work that is proceeding.

## Backwards compatible

A response with no `status` field is treated as ready, so this still behaves correctly against a deployment that has not picked up #3474 yet. That matters because the CLI and the website deploy independently — and #68 already shipped ahead of its server route once.

## Testing

40 tests in `tests/test_shell_upload.py` (5 new); full suite **612 passed**, ruff clean.

The new ones cover: an accepted file reported as uploading then ready, a failure showing its reason, a slow file handing the prompt back rather than hanging, a status-endpoint error not breaking the shell, and an already-ready response still printing "Attached".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbFY26qHgPpJUu6WTc5Ce2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploads now process asynchronously with visible pending, ready, and failed statuses.
  * The shell waits for processing to complete, reports upload failures, and returns control if processing takes too long.
  * Added support for file attachments and terminal drag-and-drop uploads.
  * Upload status can be checked and filtered by upload ID.
  * Upload paths are parsed more reliably, and sensitive information is redacted.
* **Documentation**
  * Updated the changelog with upload processing, status reporting, retry behavior, attachments, and related API details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->